### PR TITLE
Add authentication to ABR upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 !/tmp/.keep
 
 database.yml
+config/secrets.yml

--- a/app/services/abr_upload.rb
+++ b/app/services/abr_upload.rb
@@ -36,6 +36,7 @@ class AbrUpload
     Faraday.new do |conn|
       conn.request :multipart
       conn.adapter :net_http
+      conn.basic_auth 'cobra', Rails.application.secrets.abr_auth
     end.post endpoint do |req|
       upload = Faraday::UploadIO.new(StringIO.new(data.to_json), 'text/json')
       req.body = { jsonresults: upload }

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+dependencies:
+  post:
+    - mv config/secrets.example.yml config/secrets.yml

--- a/config/secrets.example.yml
+++ b/config/secrets.example.yml
@@ -12,11 +12,14 @@
 
 development:
   secret_key_base: 55ca41d1c22ee9842aeef2aa5641c063f369e142723586958bd3b36921ca7026bdbf8b98a78376510bd351f790ed99c308e8cf5633b6e4ac678a0e8ef998f6dc
+  abr_auth: ABRAUTH
 
 test:
   secret_key_base: ca42a8b2b1bb239b0350258a65bfb3e66c5f636ddc08f7d8a239aa7a10806e12a0390fc0a61835e31fa0971a93f7eab59b2a24c2ea23d16a4b125d4c4793f4e4
+  abr_auth: ABRAUTH
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  abr_auth: ABRAUTH


### PR DESCRIPTION
To allow upload to ABR production environment. Requires correct
ABR password in secrets.yml

Also removed secrets.yml from versioning since it contains protected values.