### PR TITLE
Add support for double elimination brackets

### DIFF
--- a/app/models/pairing.rb
+++ b/app/models/pairing.rb
@@ -38,4 +38,16 @@ class Pairing < ApplicationRecord
 
     player1 == player ? player2 : player1
   end
+
+  def winner
+    return if score1 == score2
+
+    score1 > score2 ? player1 : player2
+  end
+
+  def loser
+    return if score1 == score2
+
+    score1 < score2 ? player1 : player2
+  end
 end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -32,6 +32,10 @@ class Player < ApplicationRecord
     @sos_earned ||= non_bye_pairings.reported.sum { |pairing| pairing.score_for(self) }
   end
 
+  def drop!
+    update(active: false)
+  end
+
   private
 
   def destroy_pairings

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -1,16 +1,44 @@
 class Tournament < ApplicationRecord
   has_many :players, -> { order(:id) }, dependent: :destroy
   has_many :rounds, dependent: :destroy
+  belongs_to :previous, class_name: Tournament, optional: true
+  has_one :next, class_name: Tournament, foreign_key: :previous_id
 
   enum pairing_sort: {
     random: 0,
     ranked: 1
   }
 
+  enum stage: {
+    swiss: 0,
+    double_elim: 1
+  }
+
+  delegate :top, to: :standings
+
   def pair_new_round!
     number = (rounds.pluck(:number).max || 0) + 1
     rounds.create(number: number).tap do |round|
       round.pair!
+    end
+  end
+
+  def cut_to!(stage, number)
+    Tournament.create!(
+      name: name + " - Top #{number}",
+      stage: stage,
+      previous: self
+    ).tap do |t|
+      top(number).each_with_index do |player, i|
+        Player.create!(
+          name: player.name,
+          active: true,
+          corp_identity: player.corp_identity,
+          runner_identity: player.runner_identity,
+          tournament: t,
+          seed: i + 1
+        )
+      end
     end
   end
 

--- a/app/services/bracket/base.rb
+++ b/app/services/bracket/base.rb
@@ -1,0 +1,39 @@
+module Bracket
+  class Base
+    include Engine
+
+    attr_reader :tournament
+
+    def initialize(tournament)
+      @tournament = tournament
+    end
+
+    def pair(number)
+      games_for_round(number).map do |g|
+        {
+          table_number: g[:number],
+          player1: g[:player1].call(self),
+          player2: g[:player2].call(self)
+        }
+      end
+    end
+
+    def seed(number)
+      tournament.players.find { |p| p.seed == number }
+    end
+
+    def winner(number)
+      tournament.rounds
+        .map(&:pairings).flatten
+        .find{ |i| i.table_number == number }
+        .winner
+    end
+
+    def loser(number)
+      tournament.rounds
+        .map(&:pairings).flatten
+        .find{ |i| i.table_number == number }
+        .loser
+    end
+  end
+end

--- a/app/services/bracket/engine.rb
+++ b/app/services/bracket/engine.rb
@@ -1,0 +1,41 @@
+module Bracket
+  module Engine
+    def self.included(base)
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
+      def game(number, p1, p2, options = {})
+        class_eval do
+          @games ||= []
+          @games << {
+            player1: p1,
+            player2: p2,
+            round: options[:round],
+            number: number
+          }
+        end
+      end
+
+      def seed(x)
+        lambda { |context| context.seed(x) }
+      end
+
+      def winner(x)
+        lambda { |context| context.winner(x) }
+      end
+
+      def loser(x)
+        lambda { |context| context.loser(x) }
+      end
+    end
+
+    def games
+      self.class.instance_variable_get(:@games)
+    end
+
+    def games_for_round(number)
+      games.select{ |g| g[:round] == number }
+    end
+  end
+end

--- a/app/services/bracket/top4.rb
+++ b/app/services/bracket/top4.rb
@@ -1,0 +1,15 @@
+module Bracket
+  class Top4 < Base
+    game 1, seed(1), seed(4), round: 1
+    game 2, seed(2), seed(3), round: 1
+
+    game 3, winner(1), winner(2), round: 2
+    game 4, loser(1), loser(2), round: 2
+
+    game 5, loser(3), winner(4), round: 3
+
+    game 6, winner(3), winner(5), round: 4
+
+    game 7, winner(6), loser(6), round: 5
+  end
+end

--- a/app/services/bracket/top8.rb
+++ b/app/services/bracket/top8.rb
@@ -1,0 +1,25 @@
+module Bracket
+  class Top8 < Base
+    game 1, seed(1), seed(8), round: 1
+    game 2, seed(4), seed(5), round: 1
+    game 3, seed(2), seed(7), round: 1
+    game 4, seed(3), seed(6), round: 1
+
+    game 5, winner(1), winner(2), round: 2
+    game 6, winner(3), winner(4), round: 2
+    game 7, loser(1), loser(2), round: 2
+    game 8, loser(3), loser(4), round: 2
+
+    game 9, winner(5), winner(6), round: 3
+    game 10, loser(6), winner(7), round: 3
+    game 11, winner(8), loser(5), round: 3
+
+    game 12, winner(10), winner(11), round: 4
+
+    game 13, loser(9), winner(12), round: 5
+
+    game 14, winner(9), winner(13), round: 6
+
+    game 15, winner(14), loser(14), round: 7
+  end
+end

--- a/app/services/pairer.rb
+++ b/app/services/pairer.rb
@@ -7,44 +7,14 @@ class Pairer
   end
 
   def pair!
-    Swissper.pair(
-      players.to_a,
-      delta_key: :points,
-      exclude_key: :unpairable_opponents
-    ).each do |pairing|
-      round.pairings.create(pairing_params(pairing))
-    end
-    apply_numbers!(tournament.pairing_sorter)
+    strategy.new(round).pair!
   end
 
   private
 
-  def players
-    tournament.players.active
-  end
+  def strategy
+    return PairingStrategies::Swiss unless %w(swiss double_elim).include? tournament.stage
 
-  def pairing_params(pairing)
-    {
-      player1: player_from_pairing(pairing[0]),
-      player2: player_from_pairing(pairing[1]),
-      score1: auto_score(pairing, 0),
-      score2: auto_score(pairing, 1)
-    }
-  end
-
-  def player_from_pairing(player)
-    player == Swissper::Bye ? nil : player
-  end
-
-  def auto_score(pairing, player_index)
-    return unless pairing[0] == Swissper::Bye || pairing[1] == Swissper::Bye
-
-    pairing[player_index] == Swissper::Bye ? 0 : 6
-  end
-
-  def apply_numbers!(sorter)
-    sorter.sort(round.pairings).each_with_index do |pairing, i|
-      pairing.update(table_number: i + 1)
-    end
+    "PairingStrategies::#{tournament.stage.camelize}".constantize
   end
 end

--- a/app/services/pairing_strategies/base.rb
+++ b/app/services/pairing_strategies/base.rb
@@ -1,0 +1,14 @@
+module PairingStrategies
+  class Base
+    attr_reader :round
+    delegate :tournament, to: :round
+
+    def initialize(round)
+      @round = round
+    end
+
+    def players
+      tournament.players.active
+    end
+  end
+end

--- a/app/services/pairing_strategies/double_elim.rb
+++ b/app/services/pairing_strategies/double_elim.rb
@@ -1,0 +1,22 @@
+module PairingStrategies
+  class DoubleElim < Base
+    def pair!
+      bracket.new(tournament).pair(round.number).each do |pairing|
+        round.pairings.create(
+          player1: pairing[:player1],
+          player2: pairing[:player2],
+          table_number: pairing[:table_number]
+        )
+      end
+    end
+
+    private
+
+    def bracket
+      num_players = tournament.players.count
+      raise "bracket size not supported" unless [4,8].include? num_players
+
+      "Bracket::Top#{num_players}".constantize
+    end
+  end
+end

--- a/app/services/pairing_strategies/swiss.rb
+++ b/app/services/pairing_strategies/swiss.rb
@@ -1,0 +1,41 @@
+module PairingStrategies
+  class Swiss < Base
+    def pair!
+      Swissper.pair(
+        players.to_a,
+        delta_key: :points,
+        exclude_key: :unpairable_opponents
+      ).each do |pairing|
+        round.pairings.create(pairing_params(pairing))
+      end
+      apply_numbers!(tournament.pairing_sorter)
+    end
+
+    private
+
+    def pairing_params(pairing)
+      {
+        player1: player_from_pairing(pairing[0]),
+        player2: player_from_pairing(pairing[1]),
+        score1: auto_score(pairing, 0),
+        score2: auto_score(pairing, 1)
+      }
+    end
+
+    def player_from_pairing(player)
+      player == Swissper::Bye ? nil : player
+    end
+
+    def auto_score(pairing, player_index)
+      return unless pairing[0] == Swissper::Bye || pairing[1] == Swissper::Bye
+
+      pairing[player_index] == Swissper::Bye ? 0 : 6
+    end
+
+    def apply_numbers!(sorter)
+      sorter.sort(round.pairings).each_with_index do |pairing, i|
+        pairing.update(table_number: i + 1)
+      end
+    end
+  end
+end

--- a/app/services/standings.rb
+++ b/app/services/standings.rb
@@ -12,4 +12,8 @@ class Standings
   def players
     @players ||= SosCalculator.calculate!(tournament)
   end
+
+  def top(number)
+    players.map(&:player).select(&:active?)[0...number]
+  end
 end

--- a/app/views/players/standings.html.slim
+++ b/app/views/players/standings.html.slim
@@ -1,22 +1,3 @@
 h2 Standings
 
-table.pure-table.pure-table-striped.standings
-  thead
-    tr
-      th Rank
-      th Name
-      th IDs
-      th Points
-      th SOS
-      th Extended SOS
-  tbody
-    - @standings.each_with_index do |standing, i|
-      tr
-        td= i+1
-        td= standing.name
-        td.ids
-          p= standing.corp_identity
-          p= standing.runner_identity
-        td= standing.points
-        td= number_with_precision standing.sos, precision: 4
-        td= number_with_precision standing.extended_sos, precision: 4
+= render "players/standings/#{@tournament.stage}", standings: @standings

--- a/app/views/players/standings/_double_elim.html.slim
+++ b/app/views/players/standings/_double_elim.html.slim
@@ -1,0 +1,1 @@
+p Standings are not currently supported for elimination brackets

--- a/app/views/players/standings/_swiss.html.slim
+++ b/app/views/players/standings/_swiss.html.slim
@@ -1,0 +1,20 @@
+table.pure-table.pure-table-striped.standings
+  thead
+    tr
+      th Rank
+      th Name
+      th IDs
+      th Points
+      th SOS
+      th Extended SOS
+  tbody
+    - standings.each_with_index do |standing, i|
+      tr
+        td= i+1
+        td= standing.name
+        td.ids
+          p= standing.corp_identity
+          p= standing.runner_identity
+        td= standing.points
+        td= number_with_precision standing.sos, precision: 4
+        td= number_with_precision standing.extended_sos, precision: 4

--- a/db/migrate/20170624153159_add_stage_to_tournaments.rb
+++ b/db/migrate/20170624153159_add_stage_to_tournaments.rb
@@ -1,0 +1,5 @@
+class AddStageToTournaments < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tournaments, :stage, :integer, default: 0
+  end
+end

--- a/db/migrate/20170624175530_add_previous_to_tournaments.rb
+++ b/db/migrate/20170624175530_add_previous_to_tournaments.rb
@@ -1,0 +1,5 @@
+class AddPreviousToTournaments < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tournaments, :previous_id, :integer, index: true
+  end
+end

--- a/db/migrate/20170624210921_add_seed_to_players.rb
+++ b/db/migrate/20170624210921_add_seed_to_players.rb
@@ -1,0 +1,5 @@
+class AddSeedToPlayers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :players, :seed, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170505202505) do
+ActiveRecord::Schema.define(version: 20170624210921) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20170505202505) do
     t.boolean "active",          default: true
     t.string  "corp_identity"
     t.string  "runner_identity"
+    t.integer "seed"
     t.index ["tournament_id"], name: "index_players_on_tournament_id", using: :btree
   end
 
@@ -48,6 +49,8 @@ ActiveRecord::Schema.define(version: 20170505202505) do
     t.datetime "created_at"
     t.integer  "pairing_sort", default: 0
     t.string   "abr_code"
+    t.integer  "stage",        default: 0
+    t.integer  "previous_id"
   end
 
   add_foreign_key "pairings", "players", column: "player1_id"

--- a/spec/factories/tournaments.rb
+++ b/spec/factories/tournaments.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :tournament do
     name 'Tournament Name'
+    stage :swiss
 
     transient do
       player_count 0

--- a/spec/models/pairing_spec.rb
+++ b/spec/models/pairing_spec.rb
@@ -97,4 +97,20 @@ RSpec.describe Pairing do
       end
     end
   end
+
+  describe '#winner' do
+    let(:pairing) { create(:pairing, player1: jack, player2: jill, score1: 6, score2: 0) }
+
+    it 'returns winner' do
+      expect(pairing.winner).to eq(jack)
+    end
+  end
+
+  describe '#loser' do
+    let(:pairing) { create(:pairing, player1: jack, player2: jill, score1: 6, score2: 0) }
+
+    it 'returns loser' do
+      expect(pairing.loser).to eq(jill)
+    end
+  end
 end

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Player do
+  let(:player) { create(:player) }
+
   describe '#pairings' do
     let(:pairing) { create(:pairing) }
     let(:another) { create(:pairing, player2: pairing.player1) }
@@ -10,7 +12,6 @@ RSpec.describe Player do
   end
 
   describe '#non_bye_pairings' do
-    let(:player) { create(:player) }
     let!(:pairing1) { create(:pairing, player1: player) }
     let!(:pairing2) { create(:pairing, player2: player) }
     let!(:bye_pairing) { create(:pairing, player1: player, player2: nil) }
@@ -31,7 +32,6 @@ RSpec.describe Player do
   end
 
   describe 'opponents' do
-    let(:player) { create(:player) }
     let!(:pairing1) { create(:pairing, player1: player, score1: 6) }
     let!(:pairing2) { create(:pairing, player1: player, score1: 3) }
     let!(:pairing3) { create(:pairing, player1: player, player2: nil, score1: 6) }
@@ -64,6 +64,16 @@ RSpec.describe Player do
       it 'returns points earned against non-bye opponents' do
         expect(player.sos_earned).to eq(9)
       end
+    end
+  end
+
+  describe '#drop!' do
+    before do
+      player.drop!
+    end
+
+    it 'changes player status' do
+      expect(player.tournament.players.dropped).to include(player)
     end
   end
 end

--- a/spec/models/tournament_spec.rb
+++ b/spec/models/tournament_spec.rb
@@ -86,4 +86,36 @@ RSpec.describe Tournament do
       ])
     end
   end
+
+  describe '#cut_to!' do
+    let(:cut) do
+      tournament.cut_to! :double_elim, 4
+    end
+
+    before { tournament }
+
+    it 'creates elim tournament' do
+      expect do
+        cut
+      end.to change(Tournament, :count).by(1)
+    end
+
+    it 'clones players' do
+      aggregate_failures do
+        expect(cut.players.map(&:name)).to eq(tournament.top(4).map(&:name))
+        expect(cut.players.map(&:corp_identity)).to eq(tournament.top(4).map(&:corp_identity))
+        expect(cut.players.map(&:runner_identity)).to eq(tournament.top(4).map(&:runner_identity))
+        expect(cut.players.map(&:seed)).to eq([1,2,3,4])
+      end
+    end
+  end
+
+  describe '#previous' do
+    let!(:child) { create(:tournament, previous: tournament) }
+
+    it 'establishes association' do
+      expect(child.previous).to eq(tournament)
+      expect(tournament.next).to eq(child)
+    end
+  end
 end

--- a/spec/services/bracket/top4_spec.rb
+++ b/spec/services/bracket/top4_spec.rb
@@ -1,0 +1,113 @@
+RSpec.describe Bracket::Top4 do
+  let(:tournament) { create(:tournament) }
+  let(:bracket) { described_class.new(tournament) }
+  %w(alpha bravo charlie delta).each_with_index do |name, i|
+    let!(name) { create(:player, tournament: tournament, name: name, seed: i+1) }
+  end
+
+  def report(round, number, p1, score1, p2, score2)
+    create(:pairing,
+      round: round,
+      player1: p1,
+      player2: p2,
+      score1: score1,
+      score2: score2,
+      table_number: number
+    )
+  end
+
+  describe '#pair' do
+    context 'round 1' do
+      let(:pair) { bracket.pair(1) }
+
+      it 'returns correct pairings' do
+        expect(pair).to match_array([
+          { table_number: 1, player1: alpha, player2: delta },
+          { table_number: 2, player1: bravo, player2: charlie }
+        ])
+      end
+    end
+
+    context 'round 2' do
+      let(:pair) { bracket.pair(2) }
+
+      before do
+        r1 = create(:round, tournament: tournament)
+        report r1, 1, alpha, 3, delta, 0
+        report r1, 2, bravo, 3, charlie, 0
+      end
+
+      it 'returns correct pairings' do
+        expect(pair).to match_array([
+          { table_number: 3, player1: alpha, player2: bravo },
+          { table_number: 4, player1: delta, player2: charlie }
+        ])
+      end
+    end
+
+    context 'round 3' do
+      let(:pair) { bracket.pair(3) }
+
+      before do
+        r1 = create(:round, tournament: tournament)
+        report r1, 1, alpha, 3, delta, 0
+        report r1, 2, bravo, 3, charlie, 0
+
+        r2 = create(:round, tournament: tournament)
+        report r2, 3, alpha, 3, bravo, 0
+        report r2, 4, delta, 0, charlie, 3
+      end
+
+      it 'returns correct pairings' do
+        expect(pair).to match_array([
+          { table_number: 5, player1: bravo, player2: charlie }
+        ])
+      end
+    end
+
+    context 'round 4' do
+      let(:pair) { bracket.pair(4) }
+
+      before do
+        r1 = create(:round, tournament: tournament)
+        report r1, 1, alpha, 3, delta, 0
+        report r1, 2, bravo, 3, charlie, 0
+
+        r2 = create(:round, tournament: tournament)
+        report r2, 3, alpha, 3, bravo, 0
+        report r2, 4, delta, 0, charlie, 3
+
+        report r2, 5, bravo, 3, charlie, 0
+      end
+
+      it 'returns correct pairings' do
+        expect(pair).to match_array([
+          { table_number: 6, player1: alpha, player2: bravo }
+        ])
+      end
+    end
+
+    context 'round 5' do
+      let(:pair) { bracket.pair(5) }
+
+      before do
+        r1 = create(:round, tournament: tournament)
+        report r1, 1, alpha, 3, delta, 0
+        report r1, 2, bravo, 3, charlie, 0
+
+        r2 = create(:round, tournament: tournament)
+        report r2, 3, alpha, 3, bravo, 0
+        report r2, 4, delta, 0, charlie, 3
+
+        report r2, 5, bravo, 3, charlie, 0
+        report r2, 6, alpha, 0, bravo, 3
+      end
+
+      it 'returns correct pairings' do
+        expect(pair).to match_array([
+          { table_number: 7, player1: bravo, player2: alpha }
+        ])
+      end
+    end
+  end
+end

--- a/spec/services/bracket/top8_spec.rb
+++ b/spec/services/bracket/top8_spec.rb
@@ -1,0 +1,205 @@
+RSpec.describe Bracket::Top8 do
+  let(:tournament) { create(:tournament) }
+  let(:bracket) { described_class.new(tournament) }
+  %w(alpha bravo charlie delta echo foxtrot golf hotel).each_with_index do |name, i|
+    let!(name) { create(:player, tournament: tournament, name: name, seed: i+1) }
+  end
+
+  def report(round, number, p1, score1, p2, score2)
+    create(:pairing,
+      round: round,
+      player1: p1,
+      player2: p2,
+      score1: score1,
+      score2: score2,
+      table_number: number
+    )
+  end
+
+  describe '#pair' do
+    context 'round 1' do
+      let(:pair) { bracket.pair(1) }
+
+      it 'returns correct pairings' do
+        expect(pair).to match_array([
+          { table_number: 1, player1: alpha, player2: hotel },
+          { table_number: 2, player1: delta, player2: echo },
+          { table_number: 3, player1: bravo, player2: golf },
+          { table_number: 4, player1: charlie, player2: foxtrot }
+        ])
+      end
+    end
+
+    context 'round 2' do
+      let(:pair) { bracket.pair(2) }
+
+      before do
+        r1 = create(:round, tournament: tournament)
+        report r1, 1, alpha, 3, hotel, 0
+        report r1, 2, delta, 3, echo, 0
+        report r1, 3, bravo, 3, golf, 0
+        report r1, 4, charlie, 3, foxtrot, 0
+      end
+
+      it 'returns correct pairings' do
+        expect(pair).to match_array([
+          { table_number: 5, player1: alpha, player2: delta },
+          { table_number: 6, player1: bravo, player2: charlie },
+          { table_number: 7, player1: hotel, player2: echo },
+          { table_number: 8, player1: golf, player2: foxtrot }
+        ])
+      end
+    end
+
+    context 'round 3' do
+      let(:pair) { bracket.pair(3) }
+
+      before do
+        r1 = create(:round, tournament: tournament)
+        report r1, 1, alpha, 3, hotel, 0
+        report r1, 2, delta, 3, echo, 0
+        report r1, 3, bravo, 3, golf, 0
+        report r1, 4, charlie, 3, foxtrot, 0
+
+        r2 = create(:round, tournament: tournament)
+        report r2, 5, alpha, 3, delta, 0
+        report r2, 6, bravo, 3, charlie, 0
+        report r2, 7, hotel, 0, echo, 3
+        report r2, 8, golf, 0, foxtrot, 3
+      end
+
+      it 'returns correct pairings' do
+        expect(pair).to match_array([
+          { table_number: 9, player1: alpha, player2: bravo },
+          { table_number: 10, player1: charlie, player2: echo },
+          { table_number: 11, player1: foxtrot, player2: delta }
+        ])
+      end
+    end
+
+    context 'round 4' do
+      let(:pair) { bracket.pair(4) }
+
+      before do
+        r1 = create(:round, tournament: tournament)
+        report r1, 1, alpha, 3, hotel, 0
+        report r1, 2, delta, 3, echo, 0
+        report r1, 3, bravo, 3, golf, 0
+        report r1, 4, charlie, 3, foxtrot, 0
+
+        r2 = create(:round, tournament: tournament)
+        report r2, 5, alpha, 3, delta, 0
+        report r2, 6, bravo, 3, charlie, 0
+        report r2, 7, hotel, 0, echo, 3
+        report r2, 8, golf, 0, foxtrot, 3
+
+        r3 = create(:round, tournament: tournament)
+        report r3, 9, alpha, 3, bravo, 0
+        report r3, 10, charlie, 3, echo, 0
+        report r3, 11, foxtrot, 0, delta, 3
+      end
+
+      it 'returns correct pairings' do
+        expect(pair).to match_array([
+          { table_number: 12, player1: charlie, player2: delta }
+        ])
+      end
+    end
+
+    context 'round 5' do
+      let(:pair) { bracket.pair(5) }
+
+      before do
+        r1 = create(:round, tournament: tournament)
+        report r1, 1, alpha, 3, hotel, 0
+        report r1, 2, delta, 3, echo, 0
+        report r1, 3, bravo, 3, golf, 0
+        report r1, 4, charlie, 3, foxtrot, 0
+
+        r2 = create(:round, tournament: tournament)
+        report r2, 5, alpha, 3, delta, 0
+        report r2, 6, bravo, 3, charlie, 0
+        report r2, 7, hotel, 0, echo, 3
+        report r2, 8, golf, 0, foxtrot, 3
+
+        r3 = create(:round, tournament: tournament)
+        report r3, 9, alpha, 3, bravo, 0
+        report r3, 10, charlie, 3, echo, 0
+        report r3, 11, foxtrot, 0, delta, 3
+
+        report r3, 12, charlie, 3, delta, 0
+      end
+
+      it 'returns correct pairings' do
+        expect(pair).to match_array([
+          { table_number: 13, player1: bravo, player2: charlie }
+        ])
+      end
+    end
+
+    context 'round 6' do
+      let(:pair) { bracket.pair(6) }
+
+      before do
+        r1 = create(:round, tournament: tournament)
+        report r1, 1, alpha, 3, hotel, 0
+        report r1, 2, delta, 3, echo, 0
+        report r1, 3, bravo, 3, golf, 0
+        report r1, 4, charlie, 3, foxtrot, 0
+
+        r2 = create(:round, tournament: tournament)
+        report r2, 5, alpha, 3, delta, 0
+        report r2, 6, bravo, 3, charlie, 0
+        report r2, 7, hotel, 0, echo, 3
+        report r2, 8, golf, 0, foxtrot, 3
+
+        r3 = create(:round, tournament: tournament)
+        report r3, 9, alpha, 3, bravo, 0
+        report r3, 10, charlie, 3, echo, 0
+        report r3, 11, foxtrot, 0, delta, 3
+
+        report r3, 12, charlie, 3, delta, 0
+        report r3, 13, bravo, 3, charlie, 0
+      end
+
+      it 'returns correct pairings' do
+        expect(pair).to match_array([
+          { table_number: 14, player1: alpha, player2: bravo }
+        ])
+      end
+    end
+
+    context 'round 7' do
+      let(:pair) { bracket.pair(7) }
+
+      before do
+        r1 = create(:round, tournament: tournament)
+        report r1, 1, alpha, 3, hotel, 0
+        report r1, 2, delta, 3, echo, 0
+        report r1, 3, bravo, 3, golf, 0
+        report r1, 4, charlie, 3, foxtrot, 0
+
+        r2 = create(:round, tournament: tournament)
+        report r2, 5, alpha, 3, delta, 0
+        report r2, 6, bravo, 3, charlie, 0
+        report r2, 7, hotel, 0, echo, 3
+        report r2, 8, golf, 0, foxtrot, 3
+
+        r3 = create(:round, tournament: tournament)
+        report r3, 9, alpha, 3, bravo, 0
+        report r3, 10, charlie, 3, echo, 0
+        report r3, 11, foxtrot, 0, delta, 3
+
+        report r3, 12, charlie, 3, delta, 0
+        report r3, 13, bravo, 3, charlie, 0
+        report r3, 14, alpha, 0, bravo, 3
+      end
+
+      it 'returns correct pairings' do
+        expect(pair).to match_array([
+          { table_number: 15, player1: bravo, player2: alpha }
+        ])
+      end
+    end
+  end
+end

--- a/spec/services/pairing_strategies/double_elim_spec.rb
+++ b/spec/services/pairing_strategies/double_elim_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe PairingStrategies::DoubleElim do
+  let(:pairer) { described_class.new(round) }
+  let(:round) { create(:round, number: 1, tournament: tournament) }
+  let(:tournament) { create(:tournament) }
+
+  context 'top 8' do
+    %w(alpha bravo charlie delta echo foxtrot golf hotel).each_with_index do |name, i|
+      let!(name) { create(:player, tournament: tournament, name: name, seed: i+1) }
+    end
+
+    it 'creates correct pairings' do
+      pairer.pair!
+
+      round.reload
+
+      expect(round.pairings.map{ |p| [p.player1, p.player2] }).to match_array(
+        [[alpha, hotel], [bravo, golf], [charlie, foxtrot], [delta, echo]]
+      )
+      expect(round.pairings.first.table_number).to eq(1)
+    end
+
+    context 'with some results' do
+      let(:round3) { create(:round, number: 3, tournament: tournament) }
+      let(:pairer) { described_class.new(round3) }
+
+      before do
+        create(:pairing, round: round, player1: alpha, player2: hotel, score1: 3, score2: 0, table_number: 1)
+        create(:pairing, round: round, player1: bravo, player2: golf, score1: 3, score2: 0, table_number: 2)
+        create(:pairing, round: round, player1: charlie, player2: foxtrot, score1: 3, score2: 0, table_number: 3)
+        create(:pairing, round: round, player1: delta, player2: echo, score1: 3, score2: 0, table_number: 4)
+
+        create(:pairing, round: round, player1: alpha, player2: delta, score1: 3, score2: 0, table_number: 5)
+        create(:pairing, round: round, player1: bravo, player2: charlie, score1: 3, score2: 0, table_number: 6)
+        create(:pairing, round: round, player1: hotel, player2: echo, score1: 0, score2: 3, table_number: 7)
+        create(:pairing, round: round, player1: golf, player2: foxtrot, score1: 0, score2: 3, table_number: 8)
+      end
+
+      it 'creates correct pairings' do
+        pairer.pair!
+
+        round3.reload
+
+        expect(round3.pairings.map{ |p| [p.player1, p.player2] }).to match_array(
+          [[alpha, bravo], [charlie, echo], [foxtrot, delta]]
+        )
+        expect(round3.pairings.first.table_number).to eq(9)
+      end
+    end
+  end
+end

--- a/spec/services/pairing_strategies/swiss_spec.rb
+++ b/spec/services/pairing_strategies/swiss_spec.rb
@@ -1,0 +1,121 @@
+RSpec.describe PairingStrategies::Swiss do
+  let(:pairer) { described_class.new(round) }
+  let(:round) { create(:round, number: 1, tournament: tournament) }
+  let(:tournament) { create(:tournament) }
+  let(:nil_player) { double('NilPlayer', id: nil) }
+
+  before do
+    allow(NilPlayer).to receive(:new).and_return(nil_player)
+  end
+
+  context 'with four players' do
+    %i(jack jill hansel gretel).each do |name|
+      let!(name) do
+        create(:player, name: name.to_s.humanize, tournament: tournament)
+      end
+    end
+
+    it 'creates pairings' do
+      pairer.pair!
+
+      round.reload
+
+      expect(round.pairings.count).to eq(2)
+    end
+
+    context 'after some rounds' do
+      before do
+        create(:pairing, player1: jack, player2: jill, score1: 6, score2: 0)
+        create(:pairing, player1: hansel, player2: gretel, score1: 4, score2: 1)
+      end
+
+      it 'pairs based on points' do
+        pairer.pair!
+
+        round.reload
+
+        round.pairings.each do |pairing|
+          expect(pairing.players).to match_array([jack, hansel]) if pairing.players.include? jack
+          expect(pairing.players).to match_array([jill, gretel]) if pairing.players.include? jill
+        end
+      end
+
+      it 'avoids previous matchups' do
+        create(:pairing, player1: jack, player2: hansel)
+
+        pairer.pair!
+
+        round.reload
+
+        round.pairings.each do |pairing|
+          expect(pairing.players).to match_array([jack, gretel]) if pairing.players.include? jack
+          expect(pairing.players).to match_array([jill, hansel]) if pairing.players.include? jill
+        end
+      end
+    end
+  end
+
+  context 'with three players' do
+    %i(snap crackle pop).each do |name|
+      let!(name) do
+        create(:player, name: name.to_s.humanize, tournament: tournament)
+      end
+    end
+
+    it 'creates bye' do
+      pairer.pair!
+
+      round.reload
+
+      expect(
+        round.pairings.map(&:players).flatten
+      ).to contain_exactly(snap, crackle, pop, nil_player)
+    end
+
+    it 'gives win against bye' do
+      pairer.pair!
+
+      round.reload.pairings.each do |pairing|
+        expect(
+          [pairing.score1, pairing.score2]
+        ).to match_array(
+          (pairing.players.include? nil_player) ? [0,6] : [nil, nil]
+        )
+      end
+    end
+
+    context 'after multiple rounds' do
+      before do
+        create(:pairing, player1: snap, score1: 6)
+        create(:pairing, player1: crackle, score1: 3)
+        create(:pairing, player1: pop, player2: nil, score1: 1, score2: 0)
+      end
+
+      it 'avoids previous byes' do
+        pairer.pair!
+
+        round.reload
+
+        round.pairings.each do |pairing|
+          expect(pairing.players).not_to match_array([pop, nil_player]) if pairing.players.include? pop
+        end
+      end
+    end
+
+    context 'with drop' do
+      before do
+        pop.update active: false
+      end
+
+      it 'excludes dropped players' do
+        pairer.pair!
+
+        round.reload
+
+        expect(
+          round.pairings.map(&:players).flatten
+        ).to contain_exactly(snap, crackle)
+      end
+    end
+  end
+end

--- a/spec/services/standings_spec.rb
+++ b/spec/services/standings_spec.rb
@@ -20,4 +20,20 @@ RSpec.describe Standings do
       expect(standings.players.map(&:player)).to eq([hansel, gretel, jack, jill])
     end
   end
+
+  describe '#top' do
+    it 'returns top players' do
+      expect(standings.top(2)).to eq([hansel, gretel])
+    end
+
+    context 'with dropped player' do
+      before do
+        gretel.drop!
+      end
+
+      it 'returns top players' do
+        expect(standings.top(2)).to eq([hansel, jack])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Extensive refactoring of pairing services
Standings are not yet supported for brackets, and there is no interface to
cut to an elimination bracket, nor determination of sides in single-side
games.