### PR TITLE
Multiple minor fixes after regional

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,8 @@ $ cp config/secrets.example.yml config/secrets.yml
 $ rake db:create db:migrate
 $ rails server
 ```
+
+## Run tests
+```
+$ rspec
+```

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -5,8 +5,8 @@ class PlayersController < ApplicationController
   def index
     authorize @tournament, :edit?
 
-    @players = @tournament.players.active
-    @dropped = @tournament.players.dropped
+    @players = @tournament.players.active.sort_by(&:name)
+    @dropped = @tournament.players.dropped.sort_by(&:name)
   end
 
   def create

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -28,7 +28,8 @@ class Tournament < ApplicationRecord
     Tournament.create!(
       name: name + " - Top #{number}",
       stage: stage,
-      previous: self
+      previous: self,
+      user: user
     ).tap do |t|
       top(number).each_with_index do |player, i|
         Player.create!(

--- a/app/services/sos_calculator.rb
+++ b/app/services/sos_calculator.rb
@@ -33,16 +33,24 @@ class SosCalculator
 
     sos = {}
     opponents.each do |id, o|
-      sos[id] = o.sum do |player|
-        points_for_sos[player].to_f / opponents[player].count
-      end.to_f / opponents[id].count
+      if o.any?
+        sos[id] = o.sum do |player|
+          points_for_sos[player].to_f / opponents[player].count
+        end.to_f / o.count
+      else
+        sos[id] = 0.0
+      end
     end
 
     extended_sos = {}
     opponents.each do |id, o|
-      extended_sos[id] = o.sum do |player|
-        sos[player]
-      end.to_f / opponents[id].count
+      if o.any?
+        extended_sos[id] = o.sum do |player|
+          sos[player]
+        end.to_f / o.count
+      else
+        extended_sos[id] = 0.0
+      end
     end
 
     players.values.map do |p|

--- a/app/views/players/meeting.html.slim
+++ b/app/views/players/meeting.html.slim
@@ -7,7 +7,7 @@ table.pure-table.pure-table-striped
       th Player 1
       th Player 2
   tbody
-    - @tournament.players.map(&:name).in_groups_of(2).each_with_index do |pairing, i|
+    - @tournament.players.sort_by(&:name).map(&:name).in_groups_of(2).each_with_index do |pairing, i|
       tr
         td= i+1
         td= pairing[0]

--- a/spec/feature/players/list_players_spec.rb
+++ b/spec/feature/players/list_players_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe 'listing players' do
 
   before do
     tournament.players << create(:player, name: 'Jack Player')
-    tournament.players << create(:player)
+    tournament.players << create(:player, name: 'Jill Player')
     tournament.players << create(:player, active: false)
 
     sign_in tournament.user

--- a/spec/feature/players/show_player_meeting_spec.rb
+++ b/spec/feature/players/show_player_meeting_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe 'show player meeting' do
     click_link 'Player meeting'
 
     aggregate_failures do
-      expect(page).to have_content('1JackJill')
-      expect(page).to have_content('2SnapCrackle')
-      expect(page).to have_content('3Pop')
+      expect(page).to have_content('1CrackleJack')
+      expect(page).to have_content('2JillPop')
+      expect(page).to have_content('3Snap')
     end
   end
 

--- a/spec/helpers/pairings_helper_spec.rb
+++ b/spec/helpers/pairings_helper_spec.rb
@@ -35,8 +35,10 @@ RSpec.describe PairingsHelper do
     let(:undeclared) { create(:pairing, side: nil) }
 
     it 'returns side' do
-      expect(helper.side_label_for(pairing, pairing.player1)).to eq("(C)")
-      expect(helper.side_label_for(pairing, pairing.player2)).to eq("(R)")
+      aggregate_failures do
+        expect(helper.side_label_for(pairing, pairing.player1)).to eq("(Corp)")
+        expect(helper.side_label_for(pairing, pairing.player2)).to eq("(Runner)")
+      end
     end
 
     it 'returns nil for undeclared' do

--- a/spec/models/tournament_spec.rb
+++ b/spec/models/tournament_spec.rb
@@ -100,6 +100,10 @@ RSpec.describe Tournament do
       end.to change(Tournament, :count).by(1)
     end
 
+    it 'assigns tournament to previous tournament\'s user' do
+      expect(cut.user).to eq(tournament.user)
+    end
+
     it 'clones players' do
       aggregate_failures do
         expect(cut.players.map(&:name)).to eq(tournament.top(4).map(&:name))

--- a/spec/services/sos_calculator_spec.rb
+++ b/spec/services/sos_calculator_spec.rb
@@ -57,4 +57,18 @@ RSpec.describe SosCalculator do
       end
     end
   end
+
+  context 'player with only byes' do
+    before do
+      create(:pairing, player1: snap, player2: nil, score1: 6, score2: 0)
+    end
+
+    it 'calculates standing' do
+      aggregate_failures do
+        expect(standing.points).to eq(6)
+        expect(standing.sos).to eq(0.0)
+        expect(standing.extended_sos).to eq(0.0)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Made a few tweaks following use at a large regional, including:
- Alphabetising some lists of players for ease of browsing
- Fix a standings error when some players have only had byes (e.g. after first round)
- Fix permission bug when attempting to cut tournament to the next stage