### PR TITLE
Fix incorrect SOS calculations

### DIFF
--- a/app/services/sos_calculator.rb
+++ b/app/services/sos_calculator.rb
@@ -21,9 +21,9 @@ class SosCalculator
       opponents[p.player2_id] ||= []
       opponents[p.player2_id] << p.player1_id
       points_for_sos[p.player1_id] ||= 0
-      points_for_sos[p.player1_id] += p.score1 || 0 if p.player2_id
+      points_for_sos[p.player1_id] += p.score1 || 0
       points_for_sos[p.player2_id] ||= 0
-      points_for_sos[p.player2_id] += p.score2 || 0 if p.player1_id
+      points_for_sos[p.player2_id] += p.score2 || 0
     end
 
     # filter out byes from sos calculations
@@ -35,7 +35,7 @@ class SosCalculator
     opponents.each do |id, o|
       if o.any?
         sos[id] = o.sum do |player|
-          points_for_sos[player].to_f / opponents[player].count
+          points_for_sos[player].to_f / games_played[player]
         end.to_f / o.count
       else
         sos[id] = 0.0

--- a/spec/services/sos_calculator_spec.rb
+++ b/spec/services/sos_calculator_spec.rb
@@ -71,4 +71,36 @@ RSpec.describe SosCalculator do
       end
     end
   end
+
+  context 'three person tourney example' do
+    let(:three_person) { create(:tournament) }
+    let(:laurie) { create(:player, tournament: three_person) }
+    let(:dan) { create(:player, tournament: three_person) }
+    let(:johno) { create(:player, tournament: three_person) }
+    let(:results) { described_class.calculate!(three_person) }
+
+    before do
+      create(:pairing, player1: dan, player2: johno, score1: 3, score2: 3)
+      create(:pairing, player1: laurie, player2: nil, score1: 6, score2: 0)
+      create(:pairing, player1: laurie, player2: johno, score1: 6, score2: 0)
+      create(:pairing, player1: dan, player2: nil, score1: 6, score2: 0)
+    end
+
+    it 'calculates standings' do
+      aggregate_failures do
+        expect(results[0].player).to eq(laurie)
+        expect(results[0].points).to eq(12)
+        expect(results[0].sos).to eq(1.5)
+        expect(results[0].extended_sos).to eq(5.25)
+        expect(results[1].player).to eq(dan)
+        expect(results[1].points).to eq(9)
+        expect(results[1].sos).to eq(1.5)
+        expect(results[1].extended_sos).to eq(5.25)
+        expect(results[2].player).to eq(johno)
+        expect(results[2].points).to eq(3)
+        expect(results[2].sos).to eq(5.25)
+        expect(results[2].extended_sos).to eq(1.5)
+      end
+    end
+  end
 end


### PR DESCRIPTION
SOS is calculated as the average of each HUMAN opponent's "SOS
provided". Byes are excluded and cannot provide SOS.

A player's "SOS provided" is calculated as the average number of
points, per match. This total CAN include bye results.