### PR TITLE
Allow players to receive first round byes

### DIFF
--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -66,7 +66,8 @@ class PlayersController < ApplicationController
   end
 
   def player_params
-    params.require(:player).permit(:name, :corp_identity, :runner_identity)
+    params.require(:player)
+      .permit(:name, :corp_identity, :runner_identity, :first_round_bye)
   end
 
   def set_player

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -7,6 +7,7 @@ class Player < ApplicationRecord
 
   scope :active, -> { where(active: true) }
   scope :dropped, -> { where(active: false) }
+  scope :with_first_round_bye, -> { where(first_round_bye: true) }
 
   def pairings
     Pairing.for_player(self)

--- a/app/services/pairing_strategies/base.rb
+++ b/app/services/pairing_strategies/base.rb
@@ -8,7 +8,7 @@ module PairingStrategies
     end
 
     def players
-      tournament.players.active
+      @players ||= tournament.players.active
     end
   end
 end

--- a/app/views/players/index.html.slim
+++ b/app/views/players/index.html.slim
@@ -10,6 +10,7 @@ p= link_to meeting_tournament_players_path(@tournament), class: 'pure-button pur
       => f.text_field :name
       => f.text_field :corp_identity, placeholder: 'Corporation', class: 'corp_identities'
       => f.text_field :runner_identity, placeholder: 'Runner', class: 'runner_identities'
+      => f.input_field :first_round_bye, as: :boolean, inline_label: 'First round bye?'
       = button_tag type: :submit, class: 'pure-button pure-button-primary' do
         => fa_icon 'floppy-o'
         | Save
@@ -26,6 +27,7 @@ p= link_to meeting_tournament_players_path(@tournament), class: 'pure-button pur
     => f.text_field :name, placeholder: 'Name'
     => f.text_field :corp_identity, placeholder: 'Corporation', class: 'corp_identities'
     => f.text_field :runner_identity, placeholder: 'Runner', class: 'runner_identities'
+    => f.input_field :first_round_bye, as: :boolean, inline_label: 'First round bye?'
     = button_tag type: :submit, class: 'pure-button button-success' do
       => fa_icon 'plus'
       | Create

--- a/db/migrate/20170813081703_add_first_round_bye_to_players.rb
+++ b/db/migrate/20170813081703_add_first_round_bye_to_players.rb
@@ -1,0 +1,5 @@
+class AddFirstRoundByeToPlayers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :players, :first_round_bye, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170630150330) do
+ActiveRecord::Schema.define(version: 20170813081703) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 20170630150330) do
     t.string  "corp_identity"
     t.string  "runner_identity"
     t.integer "seed"
+    t.boolean "first_round_bye", default: false
     t.index ["tournament_id"], name: "index_players_on_tournament_id", using: :btree
   end
 

--- a/spec/factories/players.rb
+++ b/spec/factories/players.rb
@@ -3,5 +3,6 @@ FactoryGirl.define do
     name { Faker::Name.name }
     tournament { Tournament.first || create(:tournament) }
     active true
+    first_round_bye false
   end
 end

--- a/spec/feature/players/create_player_spec.rb
+++ b/spec/feature/players/create_player_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe 'creating a player' do
       fill_in :player_name, with: 'Jack'
       fill_in :player_corp_identity, with: 'Haas-Bioroid: Engineering the Future'
       fill_in :player_runner_identity, with: 'Noise'
+      check :player_first_round_bye
     end
 
     it 'creates player' do
@@ -31,6 +32,7 @@ RSpec.describe 'creating a player' do
         expect(subject.name).to eq('Jack')
         expect(subject.corp_identity).to eq('Haas-Bioroid: Engineering the Future')
         expect(subject.runner_identity).to eq('Noise')
+        expect(subject.first_round_bye).to eq(true)
         expect(subject.tournament).to eq(tournament)
       end
     end

--- a/spec/feature/players/update_players_spec.rb
+++ b/spec/feature/players/update_players_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'updating players' do
       fill_in :player_name, with: 'Jill Player'
       fill_in :player_corp_identity, with: 'Jinteki: Personal Evolution'
       fill_in :player_runner_identity, with: 'Gabriel Santiago'
+      check :player_first_round_bye
       click_button 'Save'
     end
   end
@@ -24,6 +25,10 @@ RSpec.describe 'updating players' do
 
   it 'can update player runner' do
     expect(tournament.players.first.runner_identity).to eq('Gabriel Santiago')
+  end
+
+  it 'can update first round bye' do
+    expect(tournament.players.first.first_round_bye).to eq(true)
   end
 
   it 'redirects to tournament player page' do


### PR DESCRIPTION
Players can be marked as having a first round bye on registration.

In the first created round, those players will receive byes and be excluded from normal pairing. Subsequent rounds are unaffected.