### PR TITLE
Improve cut tournaments

### DIFF
--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -2,6 +2,8 @@ class Player < ApplicationRecord
   include Pairable
 
   belongs_to :tournament
+  belongs_to :previous, class_name: Player, optional: true
+  has_one :next, class_name: Player, foreign_key: :previous_id
 
   before_destroy :destroy_pairings
 

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -44,7 +44,8 @@ class Tournament < ApplicationRecord
           corp_identity: player.corp_identity,
           runner_identity: player.runner_identity,
           tournament: t,
-          seed: i + 1
+          seed: i + 1,
+          previous: player
         )
       end
     end

--- a/app/services/bracket/base.rb
+++ b/app/services/bracket/base.rb
@@ -26,14 +26,32 @@ module Bracket
       tournament.rounds
         .map(&:pairings).flatten
         .find{ |i| i.table_number == number }
-        .winner
+        .try(:winner)
     end
 
     def loser(number)
       tournament.rounds
         .map(&:pairings).flatten
         .find{ |i| i.table_number == number }
-        .loser
+        .try(:loser)
+    end
+
+    def seed_of(players, pos)
+      players.map do |lam|
+        lam.call(self)
+      end.tap do |players|
+        return nil unless players.all?
+      end.sort_by(&:seed)[pos - 1]
+    end
+
+    def standings
+      self.class::STANDINGS.map do |lam|
+        if lam.is_a? Array
+          lam.map { |l| l.call(self) }.compact.try(:first)
+        else
+          lam.call(self)
+        end
+      end.map { |p| Standing.new(p) }
     end
   end
 end

--- a/app/services/bracket/engine.rb
+++ b/app/services/bracket/engine.rb
@@ -28,6 +28,10 @@ module Bracket
       def loser(x)
         lambda { |context| context.loser(x) }
       end
+
+      def seed_of(players, pos)
+        lambda { |context| context.seed_of(players, pos) }
+      end
     end
 
     def games

--- a/app/services/bracket/factory.rb
+++ b/app/services/bracket/factory.rb
@@ -1,0 +1,9 @@
+module Bracket
+  class Factory
+    def self.bracket_for(num_players)
+      raise "bracket size not supported" unless [4,8].include? num_players
+
+      "Bracket::Top#{num_players}".constantize
+    end
+  end
+end

--- a/app/services/bracket/top4.rb
+++ b/app/services/bracket/top4.rb
@@ -11,5 +11,12 @@ module Bracket
     game 6, winner(3), winner(5), round: 4
 
     game 7, winner(6), loser(6), round: 5
+
+    STANDINGS = [
+      [winner(7), winner(6)],
+      [loser(7), loser(6)],
+      loser(5),
+      loser(4)
+    ]
   end
 end

--- a/app/services/bracket/top8.rb
+++ b/app/services/bracket/top8.rb
@@ -21,5 +21,16 @@ module Bracket
     game 14, winner(9), winner(13), round: 6
 
     game 15, winner(14), loser(14), round: 7
+
+    STANDINGS = [
+      [winner(15), winner(14)],
+      [loser(15), loser(14)],
+      loser(13),
+      loser(12),
+      seed_of([loser(10), loser(11)], 1),
+      seed_of([loser(10), loser(11)], 2),
+      seed_of([loser(7), loser(8)], 1),
+      seed_of([loser(7), loser(8)], 2)
+    ]
   end
 end

--- a/app/services/nrtm_json.rb
+++ b/app/services/nrtm_json.rb
@@ -1,27 +1,84 @@
 class NrtmJson
-  attr_reader :tournament, :standings
+  attr_reader :tournament
 
   def initialize(tournament)
     @tournament = tournament
-    @standings = tournament.standings
   end
 
   def data
     {
-      name: tournament.name,
-      cutToTop: 0,
-      players: standings.each_with_index.map do |standing, i|
+      name: swiss_tournament.name,
+      date: tournament.date.to_s(:db),
+      cutToTop: cut_standings.count,
+      preliminaryRounds: swiss_rounds.count,
+      tournamentOrganiser: {
+        nrdbId: tournament.user.nrdb_id,
+        nrdbUsername: tournament.user.nrdb_username
+      },
+      players: swiss_tournament.standings.each_with_index.map do |standing, i|
         {
-          corpIdentity: standing.corp_identity,
-          runnerIdentity: standing.runner_identity,
-          rank: i+1,
           id: standing.player.id,
           name: standing.name,
+          rank: i+1,
+          corpIdentity: standing.corp_identity,
+          runnerIdentity: standing.runner_identity,
           matchPoints: standing.points,
           strengthOfSchedule: standing.sos,
           extendedStrengthOfSchedule: standing.extended_sos
         }
-      end
+      end,
+      eliminationPlayers: cut_standings.each_with_index.map do |standing, i|
+        {
+          id: standing.player.previous_id,
+          name: standing.name,
+          rank: i+1,
+          seed: standing.player.seed
+        }
+      end,
+      rounds: swiss_rounds.map do |round|
+        round.pairings.map do |pairing|
+          {
+            table: pairing.table_number,
+            player1: {
+              id: pairing.player1_id,
+              runnerScore: 0,
+              corpScore: 0,
+              combinedScore: pairing.score1
+            },
+            player2: {
+              id: pairing.player2_id,
+              runnerScore: 0,
+              corpScore: 0,
+              combinedScore: pairing.score2
+            },
+            intentionalDraw: false,
+            eliminationGame: false
+          }
+        end
+      end,
+      uploadedFrom: "Cobra",
+      links: [
+        { rel: "schemaderivedfrom", href: "http://steffens.org/nrtm/nrtm-schema.json" },
+        { rel: "uploadedfrom", href: "http://cobr.ai/#{tournament.slug}" }
+      ]
     }
+  end
+
+  private
+
+  def swiss_tournament
+    tournament.double_elim? ? tournament.previous : tournament
+  end
+
+  def swiss_rounds
+    swiss_tournament.rounds
+  end
+
+  def cut_tournament
+    tournament.double_elim? ? tournament : nil
+  end
+
+  def cut_standings
+    tournament.double_elim? ? tournament.standings : []
   end
 end

--- a/app/services/pairing_strategies/double_elim.rb
+++ b/app/services/pairing_strategies/double_elim.rb
@@ -14,10 +14,7 @@ module PairingStrategies
     private
 
     def bracket
-      num_players = tournament.players.count
-      raise "bracket size not supported" unless [4,8].include? num_players
-
-      "Bracket::Top#{num_players}".constantize
+      Bracket::Factory.bracket_for tournament.players.count
     end
   end
 end

--- a/app/services/standing.rb
+++ b/app/services/standing.rb
@@ -1,7 +1,7 @@
 class Standing
   attr_reader :player, :points, :sos, :extended_sos
 
-  delegate :name, :corp_identity, :runner_identity, to: :player
+  delegate :name, :corp_identity, :runner_identity, :seed, to: :player
 
   def initialize(player, values = {})
     @player = player

--- a/app/services/standing_strategies/base.rb
+++ b/app/services/standing_strategies/base.rb
@@ -1,0 +1,9 @@
+module StandingStrategies
+  class Base
+    attr_reader :tournament
+
+    def initialize(tournament)
+      @tournament = tournament
+    end
+  end
+end

--- a/app/services/standing_strategies/double_elim.rb
+++ b/app/services/standing_strategies/double_elim.rb
@@ -1,0 +1,13 @@
+module StandingStrategies
+  class DoubleElim < Base
+    def calculate!
+      bracket.new(tournament).standings
+    end
+
+    private
+
+    def bracket
+      Bracket::Factory.bracket_for tournament.players.count
+    end
+  end
+end

--- a/app/services/standing_strategies/swiss.rb
+++ b/app/services/standing_strategies/swiss.rb
@@ -1,0 +1,7 @@
+module StandingStrategies
+  class Swiss < Base
+    def calculate!
+      SosCalculator.calculate!(tournament)
+    end
+  end
+end

--- a/app/services/standings.rb
+++ b/app/services/standings.rb
@@ -10,10 +10,18 @@ class Standings
   end
 
   def players
-    @players ||= SosCalculator.calculate!(tournament)
+    @players ||= strategy.new(tournament).calculate!
   end
 
   def top(number)
     players.map(&:player).select(&:active?)[0...number]
+  end
+
+  private
+
+  def strategy
+    return StandingStrategies::Swiss unless %w(swiss double_elim).include? tournament.stage
+
+    "StandingStrategies::#{tournament.stage.camelize}".constantize
   end
 end

--- a/app/views/players/standings.html.slim
+++ b/app/views/players/standings.html.slim
@@ -2,6 +2,6 @@
   h2 Standings
   - if @up_to
     p After #{pluralize(@up_to, 'round')}
-    = render "players/standings/#{@tournament.stage}", standings: @standings
+    = render "players/standings/#{@tournament.stage}", standings: @standings, tournament: @tournament
   - else
     p Standings will be available after the first round has completed.

--- a/app/views/players/standings/_double_elim.html.slim
+++ b/app/views/players/standings/_double_elim.html.slim
@@ -1,1 +1,28 @@
-p Standings are not currently supported for elimination brackets
+table.table.table-striped.standings
+  thead
+    tr
+      th Rank
+      th Name
+      th IDs
+      th Seed
+  tbody
+    - standings.each_with_index do |standing, i|
+      tr
+        td= i+1
+        - if standing.player
+          td= standing.name
+          td.ids
+            p= standing.corp_identity
+            p= standing.runner_identity
+          td= standing.seed
+        - else
+          td ???
+          td.ids
+            p ???
+            p ???
+          td ???
+
+- if tournament.previous
+  h3 Previous stage
+  p After #{pluralize(tournament.previous.rounds.count, 'round')}
+  = render "players/standings/#{tournament.previous.stage}", standings: tournament.previous.standings, tournament: tournament.previous

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,7 +52,7 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.abr_host = 'http://localhost:8000'
+  config.abr_host = 'https://alwaysberunning.net'
 
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 end

--- a/db/migrate/20171123214634_add_previous_to_players.rb
+++ b/db/migrate/20171123214634_add_previous_to_players.rb
@@ -1,0 +1,5 @@
+class AddPreviousToPlayers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :players, :previous_id, :integer, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171115215730) do
+ActiveRecord::Schema.define(version: 20171123214634) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 20171115215730) do
     t.string  "runner_identity"
     t.integer "seed"
     t.boolean "first_round_bye", default: false
+    t.integer "previous_id"
     t.index ["tournament_id"], name: "index_players_on_tournament_id", using: :btree
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :user do
+    nrdb_id 1
     nrdb_username 'test_user'
   end
 end

--- a/spec/fixtures/nrtm_json_cut.json
+++ b/spec/fixtures/nrtm_json_cut.json
@@ -1,0 +1,90 @@
+{
+  "name": "Some Tournament",
+  "date": "2017-01-02",
+  "cutToTop": 4,
+  "preliminaryRounds": 1,
+  "tournamentOrganiser": {
+    "nrdbId": 123,
+    "nrdbUsername": "username"
+  },
+  "players": [
+    {
+      "id": 1001, "name": "Jack", "rank": 1, "corpIdentity": "ETF",
+      "runnerIdentity": "Noise", "matchPoints": 6, "strengthOfSchedule": 1.6,
+      "extendedStrengthOfSchedule": 2.6
+    },
+    {
+      "id": 1003, "name": "Hansel", "rank": 2, "corpIdentity": "MN",
+      "runnerIdentity": "Kate", "matchPoints": 5, "strengthOfSchedule": 1.5,
+      "extendedStrengthOfSchedule": 2.5
+    },
+    {
+      "id": 1005, "name": "Snap", "rank": 3, "corpIdentity": "ST",
+      "runnerIdentity": "Chaos Theory", "matchPoints": 4, "strengthOfSchedule": 1.4,
+      "extendedStrengthOfSchedule": 2.4
+    },
+    {
+      "id": 1007, "name": "Pop", "rank": 4, "corpIdentity": "TWIY",
+      "runnerIdentity": "Reina", "matchPoints": 3, "strengthOfSchedule": 1.3,
+      "extendedStrengthOfSchedule": 2.3
+    },
+    {
+      "id": 1006, "name": "Crackle", "rank": 5, "corpIdentity": "RP",
+      "runnerIdentity": "Andromeda", "matchPoints": 2, "strengthOfSchedule": 1.2,
+      "extendedStrengthOfSchedule": 2.2
+    },
+    {
+      "id": 1004, "name": "Gretel", "rank": 6, "corpIdentity": "BABW",
+      "runnerIdentity": "Whizzard", "matchPoints": 1, "strengthOfSchedule": 1.1,
+      "extendedStrengthOfSchedule": 2.1
+    },
+    {
+      "id": 1002, "name": "Jill", "rank": 7, "corpIdentity": "PE",
+      "runnerIdentity": "Gabe", "matchPoints": 0, "strengthOfSchedule": 1.0,
+      "extendedStrengthOfSchedule": 2.0
+    }
+  ],
+  "eliminationPlayers": [
+    { "id": 1003, "name": "Hansel", "rank": 1, "seed": 2 },
+    { "id": 1001, "name": "Jack", "rank": 2, "seed": 1 },
+    { "id": 1005, "name": "Snap", "rank": 3, "seed": 3 },
+    { "id": 1007, "name": "Pop", "rank": 4, "seed": 4 }
+  ],
+  "rounds": [
+    [
+      {
+        "table": 1,
+        "player1": { "id": 1001, "runnerScore": 0, "corpScore": 0, "combinedScore": 6 },
+        "player2": { "id": 1002, "runnerScore": 0, "corpScore": 0, "combinedScore": 0 },
+        "intentionalDraw": false,
+        "eliminationGame": false
+      },
+      {
+        "table": 2,
+        "player1": { "id": 1003, "runnerScore": 0, "corpScore": 0, "combinedScore": 5 },
+        "player2": { "id": 1004, "runnerScore": 0, "corpScore": 0, "combinedScore": 1 },
+        "intentionalDraw": false,
+        "eliminationGame": false
+      },
+      {
+        "table": 3,
+        "player1": { "id": 1005, "runnerScore": 0, "corpScore": 0, "combinedScore": 4 },
+        "player2": { "id": 1006, "runnerScore": 0, "corpScore": 0, "combinedScore": 2 },
+        "intentionalDraw": false,
+        "eliminationGame": false
+      },
+      {
+        "table": 4,
+        "player1": { "id": 1007, "runnerScore": 0, "corpScore": 0, "combinedScore": 3 },
+        "player2": { "id": null, "runnerScore": 0, "corpScore": 0, "combinedScore": 0 },
+        "intentionalDraw": false,
+        "eliminationGame": false
+      }
+    ]
+  ],
+  "uploadedFrom": "Cobra",
+  "links": [
+    { "rel": "schemaderivedfrom", "href": "http://steffens.org/nrtm/nrtm-schema.json" },
+    { "rel": "uploadedfrom", "href": "http://cobr.ai/CUTT" }
+  ]
+}

--- a/spec/fixtures/nrtm_json_swiss.json
+++ b/spec/fixtures/nrtm_json_swiss.json
@@ -1,0 +1,85 @@
+{
+  "name": "Some Tournament",
+  "date": "2017-01-01",
+  "cutToTop": 0,
+  "preliminaryRounds": 1,
+  "tournamentOrganiser": {
+    "nrdbId": 123,
+    "nrdbUsername": "username"
+  },
+  "players": [
+    {
+      "id": 1001, "name": "Jack", "rank": 1, "corpIdentity": "ETF",
+      "runnerIdentity": "Noise", "matchPoints": 6, "strengthOfSchedule": 1.6,
+      "extendedStrengthOfSchedule": 2.6
+    },
+    {
+      "id": 1003, "name": "Hansel", "rank": 2, "corpIdentity": "MN",
+      "runnerIdentity": "Kate", "matchPoints": 5, "strengthOfSchedule": 1.5,
+      "extendedStrengthOfSchedule": 2.5
+    },
+    {
+      "id": 1005, "name": "Snap", "rank": 3, "corpIdentity": "ST",
+      "runnerIdentity": "Chaos Theory", "matchPoints": 4, "strengthOfSchedule": 1.4,
+      "extendedStrengthOfSchedule": 2.4
+    },
+    {
+      "id": 1007, "name": "Pop", "rank": 4, "corpIdentity": "TWIY",
+      "runnerIdentity": "Reina", "matchPoints": 3, "strengthOfSchedule": 1.3,
+      "extendedStrengthOfSchedule": 2.3
+    },
+    {
+      "id": 1006, "name": "Crackle", "rank": 5, "corpIdentity": "RP",
+      "runnerIdentity": "Andromeda", "matchPoints": 2, "strengthOfSchedule": 1.2,
+      "extendedStrengthOfSchedule": 2.2
+    },
+    {
+      "id": 1004, "name": "Gretel", "rank": 6, "corpIdentity": "BABW",
+      "runnerIdentity": "Whizzard", "matchPoints": 1, "strengthOfSchedule": 1.1,
+      "extendedStrengthOfSchedule": 2.1
+    },
+    {
+      "id": 1002, "name": "Jill", "rank": 7, "corpIdentity": "PE",
+      "runnerIdentity": "Gabe", "matchPoints": 0, "strengthOfSchedule": 1.0,
+      "extendedStrengthOfSchedule": 2.0
+    }
+  ],
+  "eliminationPlayers": [],
+  "rounds": [
+    [
+      {
+        "table": 1,
+        "player1": { "id": 1001, "runnerScore": 0, "corpScore": 0, "combinedScore": 6 },
+        "player2": { "id": 1002, "runnerScore": 0, "corpScore": 0, "combinedScore": 0 },
+        "intentionalDraw": false,
+        "eliminationGame": false
+      },
+      {
+        "table": 2,
+        "player1": { "id": 1003, "runnerScore": 0, "corpScore": 0, "combinedScore": 5 },
+        "player2": { "id": 1004, "runnerScore": 0, "corpScore": 0, "combinedScore": 1 },
+        "intentionalDraw": false,
+        "eliminationGame": false
+      },
+      {
+        "table": 3,
+        "player1": { "id": 1005, "runnerScore": 0, "corpScore": 0, "combinedScore": 4 },
+        "player2": { "id": 1006, "runnerScore": 0, "corpScore": 0, "combinedScore": 2 },
+        "intentionalDraw": false,
+        "eliminationGame": false
+      },
+      {
+        "table": 4,
+        "player1": { "id": 1007, "runnerScore": 0, "corpScore": 0, "combinedScore": 3 },
+        "player2": { "id": null, "runnerScore": 0, "corpScore": 0, "combinedScore": 0 },
+        "intentionalDraw": false,
+        "eliminationGame": false
+      }
+    ]
+  ],
+  "uploadedFrom": "Cobra",
+  "links": [
+    { "rel": "schemaderivedfrom", "href": "http://steffens.org/nrtm/nrtm-schema.json" },
+    { "rel": "uploadedfrom", "href": "http://cobr.ai/SLUG" }
+  ]
+}

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,6 +23,7 @@ RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
 
   config.include SignIn
+  config.include Report
 
   config.before(:suite) do
     DatabaseCleaner.strategy = :transaction

--- a/spec/requests/tournaments_controller_spec.rb
+++ b/spec/requests/tournaments_controller_spec.rb
@@ -2,19 +2,19 @@ RSpec.describe TournamentsController do
   let(:tournament) { create(:tournament, name: 'My Tournament') }
 
   describe '#save_json' do
+    before do
+      allow(NrtmJson).to receive(:new).with(tournament).and_return(
+        double(:json, data: { some: :data })
+      )
+    end
+
     it 'responds with json file' do
       get save_json_tournament_path(tournament)
 
       expect(response.headers['Content-Disposition']).to eq(
         'attachment; filename="my tournament.json"'
       )
-      expect(response.body).to eq(
-        {
-          name: 'My Tournament',
-          cutToTop: 0,
-          players: []
-        }.to_json
-      )
+      expect(response.body).to eq("{\"some\":\"data\"}")
     end
   end
 

--- a/spec/services/bracket/top4_spec.rb
+++ b/spec/services/bracket/top4_spec.rb
@@ -5,17 +5,6 @@ RSpec.describe Bracket::Top4 do
     let!(name) { create(:player, tournament: tournament, name: name, seed: i+1) }
   end
 
-  def report(round, number, p1, score1, p2, score2)
-    create(:pairing,
-      round: round,
-      player1: p1,
-      player2: p2,
-      score1: score1,
-      score2: score2,
-      table_number: number
-    )
-  end
-
   describe '#pair' do
     context 'round 1' do
       let(:pair) { bracket.pair(1) }
@@ -108,6 +97,28 @@ RSpec.describe Bracket::Top4 do
           { table_number: 7, player1: bravo, player2: alpha }
         ])
       end
+    end
+  end
+
+  describe '#standings' do
+    before do
+      r1 = create(:round, tournament: tournament)
+      report r1, 1, alpha, 3, delta, 0
+      report r1, 2, bravo, 3, charlie, 0
+
+      r2 = create(:round, tournament: tournament)
+      report r2, 3, alpha, 3, bravo, 0
+      report r2, 4, delta, 0, charlie, 3
+
+      report r2, 5, bravo, 3, charlie, 0
+      report r2, 6, alpha, 0, bravo, 3
+      report r2, 7, bravo, 3, alpha, 0
+    end
+
+    it 'returns correct standings' do
+      expect(bracket.standings.map(&:player)).to eq(
+        [bravo, alpha, charlie, delta]
+      )
     end
   end
 end

--- a/spec/services/bracket/top8_spec.rb
+++ b/spec/services/bracket/top8_spec.rb
@@ -5,17 +5,6 @@ RSpec.describe Bracket::Top8 do
     let!(name) { create(:player, tournament: tournament, name: name, seed: i+1) }
   end
 
-  def report(round, number, p1, score1, p2, score2)
-    create(:pairing,
-      round: round,
-      player1: p1,
-      player2: p2,
-      score1: score1,
-      score2: score2,
-      table_number: number
-    )
-  end
-
   describe '#pair' do
     context 'round 1' do
       let(:pair) { bracket.pair(1) }
@@ -200,6 +189,38 @@ RSpec.describe Bracket::Top8 do
           { table_number: 15, player1: bravo, player2: alpha }
         ])
       end
+    end
+  end
+
+  describe '#standings' do
+    before do
+      r1 = create(:round, tournament: tournament)
+      report r1, 1, alpha, 3, hotel, 0
+      report r1, 2, delta, 3, echo, 0
+      report r1, 3, bravo, 3, golf, 0
+      report r1, 4, charlie, 3, foxtrot, 0
+
+      r2 = create(:round, tournament: tournament)
+      report r2, 5, alpha, 3, delta, 0
+      report r2, 6, bravo, 3, charlie, 0
+      report r2, 7, hotel, 0, echo, 3
+      report r2, 8, golf, 0, foxtrot, 3
+
+      r3 = create(:round, tournament: tournament)
+      report r3, 9, alpha, 3, bravo, 0
+      report r3, 10, charlie, 3, echo, 0
+      report r3, 11, foxtrot, 0, delta, 3
+
+      report r3, 12, charlie, 3, delta, 0
+      report r3, 13, bravo, 3, charlie, 0
+      report r3, 14, alpha, 0, bravo, 3
+      report r3, 15, bravo, 3, alpha, 0
+    end
+
+    it 'returns correct standings' do
+      expect(bracket.standings.map(&:player)).to eq(
+        [bravo, alpha, charlie, delta, echo, foxtrot, golf, hotel]
+      )
     end
   end
 end

--- a/spec/services/nrtm_json_spec.rb
+++ b/spec/services/nrtm_json_spec.rb
@@ -1,50 +1,75 @@
 RSpec.describe NrtmJson do
-  let(:tournament) { create(:tournament, name: 'Some Tournament') }
-  let(:jack) { create(:player, corp_identity: 'ETF', runner_identity: 'Noise') }
-  let(:jill) { create(:player, corp_identity: 'PE', runner_identity: 'Gabe') }
+  let(:to) { create(:user, nrdb_id: 123, nrdb_username: 'username') }
+  let(:tournament) { create(:tournament, name: 'Some Tournament', user: to, slug: 'SLUG', date: '2017-01-01') }
+  let(:jack) { create(:player, name: 'Jack', corp_identity: 'ETF', runner_identity: 'Noise', id: 1001) }
+  let(:jill) { create(:player, name: 'Jill', corp_identity: 'PE', runner_identity: 'Gabe', id: 1002) }
+  let(:hansel) { create(:player, name: 'Hansel', corp_identity: 'MN', runner_identity: 'Kate', id: 1003) }
+  let(:gretel) { create(:player, name: 'Gretel', corp_identity: 'BABW', runner_identity: 'Whizzard', id: 1004) }
+  let(:snap) { create(:player, name: 'Snap', corp_identity: 'ST', runner_identity: 'Chaos Theory', id: 1005) }
+  let(:crackle) { create(:player, name: 'Crackle', corp_identity: 'RP', runner_identity: 'Andromeda', id: 1006) }
+  let(:pop) { create(:player, name: 'Pop', corp_identity: 'TWIY', runner_identity: 'Reina', id: 1007) }
   let(:round) { create(:round, tournament: tournament) }
 
   let(:json) { described_class.new(tournament) }
 
   before do
-    round.pairings << create(:pairing, player1: jack, player2: jill)
+    round.pairings << create(:pairing, player1: jack, player2: jill, table_number: 1, score1: 6, score2: 0)
+    round.pairings << create(:pairing, player1: hansel, player2: gretel, table_number: 2, score1: 5, score2: 1)
+    round.pairings << create(:pairing, player1: snap, player2: crackle, table_number: 3, score1: 4, score2: 2)
+    round.pairings << create(:pairing, player1: pop, player2: nil, table_number: 4, score1: 3, score2: 0)
   end
 
   describe '#data' do
     before do
-      allow(tournament).to receive(:standings).and_return([
-        Standing.new(jack, points: 6),
-        Standing.new(jill, points: 0)
-      ])
+      allow(StandingStrategies::Swiss).to receive(:new)
+        .with(tournament)
+        .and_return(
+          double(
+            :standings,
+            calculate!: [
+              Standing.new(jack, points: 6, sos: 1.6, extended_sos: 2.6),
+              Standing.new(hansel, points: 5, sos: 1.5, extended_sos: 2.5),
+              Standing.new(snap, points: 4, sos: 1.4, extended_sos: 2.4),
+              Standing.new(pop, points: 3, sos: 1.3, extended_sos: 2.3),
+              Standing.new(crackle, points: 2, sos: 1.2, extended_sos: 2.2),
+              Standing.new(gretel, points: 1, sos: 1.1, extended_sos: 2.1),
+              Standing.new(jill, points: 0, sos: 1.0, extended_sos: 2.0)
+            ]
+          )
+        )
     end
 
     it 'returns hash of data' do
-      expect(json.data).to eq({
-        name: 'Some Tournament',
-        cutToTop: 0,
-        players: [
-          {
-            corpIdentity: 'ETF',
-            runnerIdentity: 'Noise',
-            rank: 1,
-            id: jack.id,
-            name: jack.name,
-            matchPoints: 6,
-            strengthOfSchedule: 0,
-            extendedStrengthOfSchedule: 0
-          },
-          {
-            corpIdentity: 'PE',
-            runnerIdentity: 'Gabe',
-            rank: 2,
-            id: jill.id,
-            name: jill.name,
-            matchPoints: 0,
-            strengthOfSchedule: 0,
-            extendedStrengthOfSchedule: 0
-          }
-        ]
-      })
+      expect(json.data.with_indifferent_access).to eq(
+        JSON.parse(File.read('spec/fixtures/nrtm_json_swiss.json'))
+      )
+    end
+
+    context 'with elimination bracket' do
+      let(:cut) { tournament.cut_to! :double_elim, 4 }
+      let(:json) { described_class.new(cut) }
+
+      before do
+        cut.update(date: '2017-01-02', slug: 'CUTT')
+
+        r1 = create(:round, tournament: cut)
+        report r1, 1, jack.next, 3, pop.next, 0
+        report r1, 2, hansel.next, 3, snap.next, 0
+
+        r2 = create(:round, tournament: cut)
+        report r2, 3, jack.next, 3, hansel.next, 0
+        report r2, 4, pop.next, 0, snap.next, 3
+
+        report r2, 5, hansel.next, 3, snap.next, 0
+        report r2, 6, jack.next, 0, hansel.next, 3
+        report r2, 7, hansel.next, 3, jack.next, 0
+      end
+
+      it 'returns hash of data' do
+        expect(json.data.with_indifferent_access).to eq(
+          JSON.parse(File.read('spec/fixtures/nrtm_json_cut.json'))
+        )
+      end
     end
   end
 end

--- a/spec/services/standings_spec.rb
+++ b/spec/services/standings_spec.rb
@@ -19,6 +19,35 @@ RSpec.describe Standings do
     it 'ranks players' do
       expect(standings.players.map(&:player)).to eq([hansel, gretel, jack, jill])
     end
+
+    describe 'double elim bracket' do
+      let(:cut) { tournament.cut_to! :double_elim, 4 }
+      let(:standings) { described_class.new(cut) }
+
+      let(:elim1) { create(:round, tournament: cut) }
+      let(:elim2) { create(:round, tournament: cut) }
+      let(:elim3) { create(:round, tournament: cut) }
+      let(:elim4) { create(:round, tournament: cut) }
+      let(:elim5) { create(:round, tournament: cut) }
+
+      before do
+        elim1.pairings << create(:pairing, player1: hansel, player2: jill, table_number: 1, score1: 3, score2: 0)
+        elim1.pairings << create(:pairing, player1: gretel, player2: jack, table_number: 2, score1: 3, score2: 0)
+
+        elim2.pairings << create(:pairing, player1: hansel, player2: gretel, table_number: 3, score1: 0, score2: 3)
+        elim2.pairings << create(:pairing, player1: jill, player2: jack, table_number: 4, score1: 3, score2: 0)
+
+        elim3.pairings << create(:pairing, player1: hansel, player2: jill, table_number: 5, score1: 0, score2: 3)
+
+        elim4.pairings << create(:pairing, player1: gretel, player2: jill, table_number: 6, score1: 0, score2: 3)
+
+        elim5.pairings << create(:pairing, player1: jill, player2: gretel, table_number: 7, score1: 0, score2: 3)
+      end
+
+      it 'ranks players' do
+        expect(standings.players.map(&:player)).to eq([gretel, jill, hansel, jack])
+      end
+    end
   end
 
   describe '#top' do

--- a/spec/support/report.rb
+++ b/spec/support/report.rb
@@ -1,0 +1,12 @@
+module Report
+  def report(round, number, p1, score1, p2, score2)
+    create(:pairing,
+      round: round,
+      player1: p1,
+      player2: p2,
+      score1: score1,
+      score2: score2,
+      table_number: number
+    )
+  end
+end


### PR DESCRIPTION
Add double elim standings and previous stage standings.
Amend JSON to include much more info, including swiss pairings
and elim data.
Strategised standings to allow for other formats.
Linked players to the equivalent player in the previous stage.