### PR TITLE
Allow rounds to be weighted for SOS calculations

### DIFF
--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -1,6 +1,6 @@
 class RoundsController < ApplicationController
   before_action :set_tournament
-  before_action :set_round, only: [:show, :destroy, :repair, :complete]
+  before_action :set_round, only: [:show, :edit, :update, :destroy, :repair, :complete]
 
   def index
     authorize @tournament, :show?
@@ -19,6 +19,18 @@ class RoundsController < ApplicationController
     @tournament.pair_new_round!
 
     redirect_to tournament_rounds_path(@tournament)
+  end
+
+  def edit
+    authorize @tournament, :update?
+  end
+
+  def update
+    authorize @tournament, :update?
+
+    @round.update(round_params)
+
+    redirect_to tournament_round_path(@tournament, @round)
   end
 
   def destroy
@@ -49,5 +61,9 @@ class RoundsController < ApplicationController
 
   def set_round
     @round = Round.find(params[:id])
+  end
+
+  def round_params
+    params.require(:round).permit(:weight)
   end
 end

--- a/app/services/sos_calculator.rb
+++ b/app/services/sos_calculator.rb
@@ -13,13 +13,13 @@ class SosCalculator
       points[p.player2_id] ||= 0
       points[p.player2_id] += p.score2 || 0
       games_played[p.player1_id] ||= 0
-      games_played[p.player1_id] += 1
+      games_played[p.player1_id] += p.round.weight
       games_played[p.player2_id] ||= 0
-      games_played[p.player2_id] += 1
+      games_played[p.player2_id] += p.round.weight
       opponents[p.player1_id] ||= []
-      opponents[p.player1_id] << p.player2_id
+      opponents[p.player1_id] << { id: p.player2_id, weight: p.round.weight }
       opponents[p.player2_id] ||= []
-      opponents[p.player2_id] << p.player1_id
+      opponents[p.player2_id] << { id: p.player1_id, weight: p.round.weight }
       points_for_sos[p.player1_id] ||= 0
       points_for_sos[p.player1_id] += p.score1 || 0
       points_for_sos[p.player2_id] ||= 0
@@ -28,15 +28,15 @@ class SosCalculator
 
     # filter out byes from sos calculations
     opponents.each do |k, i|
-      opponents[k] = i.compact
+      opponents[k] = i.select { |player| player[:id] }
     end
 
     sos = {}
     opponents.each do |id, o|
       if o.any?
         sos[id] = o.sum do |player|
-          points_for_sos[player].to_f / games_played[player]
-        end.to_f / o.count
+          player[:weight] * points_for_sos[player[:id]].to_f / games_played[player[:id]]
+        end.to_f / o.inject(0) { |i, player| i += player[:weight] if player[:id] }
       else
         sos[id] = 0.0
       end
@@ -46,8 +46,8 @@ class SosCalculator
     opponents.each do |id, o|
       if o.any?
         extended_sos[id] = o.sum do |player|
-          sos[player]
-        end.to_f / o.count
+          player[:weight] * sos[player[:id]]
+        end.to_f / o.inject(0) { |i, player| i += player[:weight] if player[:id] }
       else
         extended_sos[id] = 0.0
       end

--- a/app/views/rounds/edit.html.slim
+++ b/app/views/rounds/edit.html.slim
@@ -1,0 +1,15 @@
+.col-12
+  h2= "Round #{@round.number}: Advanced Settings"
+  => link_to tournament_round_path(@tournament, @round), class: 'btn btn-primary' do
+    => fa_icon 'arrow-left'
+    | Back to round
+.col-12.mt-3
+  .row
+    .col-4
+      = simple_form_for @round, url: tournament_round_path(@tournament, @round) do |f|
+        .form-group
+          = f.input :weight, input_html: { class: 'form-control' }, label: 'SOS Weighting'
+        .form-group
+          = button_tag type: :submit, class: 'btn btn-primary' do |f|
+            => fa_icon 'floppy-o'
+            | Save

--- a/app/views/rounds/show.html.slim
+++ b/app/views/rounds/show.html.slim
@@ -15,6 +15,9 @@
       => link_to complete_tournament_round_path(@round.tournament, @round, completed: true), method: :patch, class: 'btn btn-warning' do
         => fa_icon 'check'
         | Complete
+    => link_to edit_tournament_round_path(@round.tournament, @round), class: 'btn btn-warning' do
+      => fa_icon 'wrench'
+      | Advanced
     = link_to tournament_round_path(@round.tournament, @round), method: :delete, class: 'btn btn-danger', data: { confirm: 'Are you sure? This cannot be reversed.' } do
       => fa_icon 'trash'
       | Delete round

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
       patch :drop, on: :member
       patch :reinstate, on: :member
     end
-    resources :rounds, only: [:index, :show, :create, :destroy] do
+    resources :rounds, only: [:index, :show, :create, :edit, :update, :destroy] do
       resources :pairings, only: [:index, :create, :destroy] do
         post :report, on: :member
         get :match_slips, on: :collection

--- a/db/migrate/20171205104445_add_weight_to_rounds.rb
+++ b/db/migrate/20171205104445_add_weight_to_rounds.rb
@@ -1,0 +1,5 @@
+class AddWeightToRounds < ActiveRecord::Migration[5.0]
+  def change
+    add_column :rounds, :weight, :decimal, default: 1.0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171126092352) do
+ActiveRecord::Schema.define(version: 20171205104445) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 20171126092352) do
     t.integer "tournament_id"
     t.integer "number"
     t.boolean "completed",     default: false
+    t.decimal "weight",        default: "1.0"
     t.index ["tournament_id"], name: "index_rounds_on_tournament_id", using: :btree
   end
 

--- a/spec/factories/rounds.rb
+++ b/spec/factories/rounds.rb
@@ -3,5 +3,6 @@ FactoryGirl.define do
     number 1
     tournament
     completed false
+    weight 1.0
   end
 end

--- a/spec/feature/rounds/edit_round_spec.rb
+++ b/spec/feature/rounds/edit_round_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe 'making advanced round edits' do
+  let(:round) { create(:round, weight: 1.0) }
+
+  before do
+    sign_in round.tournament.user
+    visit tournament_round_path(round.tournament, round)
+    click_link 'Advanced'
+  end
+
+  it 'allows the user to edit round weighting' do
+    fill_in 'SOS Weighting', with: 0.8
+    click_button 'Save'
+
+    expect(round.reload.weight).to eq(0.8)
+  end
+end

--- a/spec/services/sos_calculator_spec.rb
+++ b/spec/services/sos_calculator_spec.rb
@@ -104,4 +104,43 @@ RSpec.describe SosCalculator do
       end
     end
   end
+
+  context 'weighted round example' do
+    let(:weighted) { create(:tournament) }
+    let(:alpha) { create(:player, tournament: weighted) }
+    let(:beta) { create(:player, tournament: weighted) }
+    let(:gamma) { create(:player, tournament: weighted) }
+    let(:delta) { create(:player, tournament: weighted) }
+    let(:round1) { create(:round, tournament: weighted, weight: 1.0, completed: true) }
+    let(:round2) { create(:round, tournament: weighted, weight: 0.5, completed: true) }
+    let(:results) { described_class.calculate!(weighted) }
+
+    before do
+      create(:pairing, player1: alpha, player2: beta, score1: 6, score2: 0, round: round1)
+      create(:pairing, player1: gamma, player2: delta, score1: 3, score2: 3, round: round1)
+      create(:pairing, player1: alpha, player2: gamma, score1: 3, score2: 0, round: round2)
+      create(:pairing, player1: beta, player2: delta, score1: 0, score2: 3, round: round2)
+    end
+
+    it 'calculates weighted SOS' do
+      aggregate_failures do
+        expect(results[0].player).to eq(alpha)
+        expect(results[0].points).to eq(9)
+        expect(results[0].sos.round(4)).to eq(0.6667)
+        expect(results[0].extended_sos.round(4)).to eq(5.1111)
+        expect(results[1].player).to eq(delta)
+        expect(results[1].points).to eq(6)
+        expect(results[1].sos.round(4)).to eq(1.3333)
+        expect(results[1].extended_sos.round(4)).to eq(4.8889)
+        expect(results[2].player).to eq(gamma)
+        expect(results[2].points).to eq(3)
+        expect(results[2].sos.round(4)).to eq(4.6667)
+        expect(results[2].extended_sos.round(4)).to eq(1.1111)
+        expect(results[3].player).to eq(beta)
+        expect(results[3].points).to eq(0)
+        expect(results[3].sos.round(4)).to eq(5.3333)
+        expect(results[3].extended_sos.round(4)).to eq(0.8889)
+      end
+    end
+  end
 end


### PR DESCRIPTION
In hypothetical tournaments which weight some rounds over others,
SOS calculations should take the round weighting into account.

For example, in a swiss tournament which includes some single-sided
rounds, those rounds would need to be weighted at 0.5 of a normal
round, due to the players in that round only playing a single game.