### PR TITLE
Allow cross-origin requests to API endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 5.0.2'
-gem 'pg'
+gem 'pg', '~> 0.18'
 gem 'puma', '~> 3.0'
 gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
     nio4r (2.1.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
-    pg (0.19.0)
+    pg (0.21.0)
     popper_js (1.11.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -156,7 +156,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     raindrops (0.19.0)
-    rake (12.2.1)
+    rake (12.3.1)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
@@ -251,7 +251,7 @@ DEPENDENCIES
   jquery-rails
   launchy
   listen
-  pg
+  pg (~> 0.18)
   pry
   puma (~> 3.0)
   pundit

--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -27,7 +27,10 @@ class TournamentsController < ApplicationController
         @players = @tournament.players.active.sort_by(&:name)
         @dropped = @tournament.players.dropped.sort_by(&:name)
       end
-      format.json { render json: NrtmJson.new(@tournament).data }
+      format.json do
+        headers['Access-Control-Allow-Origin'] = '*'
+        render json: NrtmJson.new(@tournament).data
+      end
     end
   end
 

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -72,4 +72,4 @@ html
           .col-4.nav-item.text-center
            | Made with 🐍 by Johno
           .col-4.nav-item.text-right
-            = link_to 'v1.1.0', 'https://github.com/muyjohno/cobra/releases', class: 'text-muted'
+            = link_to 'v1.1.1', 'https://github.com/muyjohno/cobra/releases', class: 'text-muted'


### PR DESCRIPTION
Only added to the JSON endpoint as a quick fix. If real API development is done, this should probably be handled better.