### PR TITLE
Make some improvements for larger tournaments

### DIFF
--- a/app/assets/javascripts/pairings.js.coffee
+++ b/app/assets/javascripts/pairings.js.coffee
@@ -2,3 +2,12 @@ $(document).on 'turbolinks:load', ->
   $('.toggle_custom_score').on 'click', (e) ->
     $(@).parents('.round_pairing').find('.preset_score, .custom_score').toggle()
     e.preventDefault()
+
+  if JSON.parse(localStorage['hide_reported'])
+    $('.reported').hide()
+  else
+    $('.reported_hidden_message').hide()
+  $('#toggle_reported').on 'click', (e) ->
+    $('.reported').toggle()
+    $('.reported_hidden_message').toggle()
+    localStorage['hide_reported'] = !JSON.parse(localStorage['hide_reported'])

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -5,8 +5,8 @@ class PlayersController < ApplicationController
   def index
     authorize @tournament, :update?
 
-    @players = @tournament.players.active.sort_by(&:name)
-    @dropped = @tournament.players.dropped.sort_by(&:name)
+    @players = @tournament.players.active.sort_by { |p| p.name || '' }
+    @dropped = @tournament.players.dropped.sort_by { |p| p.name || '' }
   end
 
   def create

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -4,10 +4,12 @@ class RoundsController < ApplicationController
 
   def index
     authorize @tournament, :show?
+    @players = @tournament.players.index_by(&:id).merge({ nil => NilPlayer.new })
   end
 
   def show
     authorize @tournament, :update?
+    @players = @tournament.players.index_by(&:id).merge({ nil => NilPlayer.new })
   end
 
   def create

--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -24,8 +24,8 @@ class TournamentsController < ApplicationController
 
     respond_to do |format|
       format.html do
-        @players = @tournament.players.active.sort_by(&:name)
-        @dropped = @tournament.players.dropped.sort_by(&:name)
+        @players = @tournament.players.active.sort_by { |p| p.name || '' }
+        @dropped = @tournament.players.dropped.sort_by { |p| p.name || '' }
       end
       format.json do
         headers['Access-Control-Allow-Origin'] = '*'

--- a/app/helpers/pairings_helper.rb
+++ b/app/helpers/pairings_helper.rb
@@ -21,7 +21,7 @@ module PairingsHelper
   end
 
   def side_value(player, side, pairing)
-    return unless pairing.players.include? player
+    return unless player_is_in_pairing(player, pairing)
 
     [:player1_is_corp, :player1_is_runner].tap do |options|
       options.reverse! if (side == :runner) ^ (pairing.player2 == player)
@@ -29,7 +29,7 @@ module PairingsHelper
   end
 
   def set_side_button(player, side, pairing)
-    return unless pairing.players.include? player
+    return unless player_is_in_pairing(player, pairing)
 
     value = side_value(player, side, pairing)
     active = (pairing.side.try(:to_sym) == value)
@@ -37,7 +37,7 @@ module PairingsHelper
     link_to side.capitalize,
       report_tournament_round_pairing_path(
         pairing.tournament,
-        pairing.round,
+        pairing.round_id,
         pairing,
         pairing: { side: value }
       ),
@@ -56,8 +56,12 @@ module PairingsHelper
   end
 
   def side_label_for(pairing, player)
-    return nil unless pairing.side && pairing.players.include?(player)
+    return nil unless pairing.side && player_is_in_pairing(player, pairing)
 
     "(#{pairing.side_for(player).to_s.titleize})"
+  end
+
+  def player_is_in_pairing(player, pairing)
+    pairing.player1_id == player.id || pairing.player2_id == player.id
   end
 end

--- a/app/views/players/index.html.slim
+++ b/app/views/players/index.html.slim
@@ -4,6 +4,18 @@
       => fa_icon 'list'
       | Player meeting
 
+  h3.mt-4 Register player
+  = simple_form_for :player, url: tournament_players_path(@tournament), html: { class: 'form-inline identities_form' } do |f|
+    => f.text_field :name, placeholder: 'Name', class: 'form-control mr-2'
+    => f.text_field :corp_identity, placeholder: 'Corporation', class: 'corp_identities form-control mr-2'
+    => f.text_field :runner_identity, placeholder: 'Runner', class: 'runner_identities form-control mr-2'
+    .form-check.mr-2
+      => f.input_field :first_round_bye, as: :boolean, inline_label: 'First round bye?', class: 'form-check-input'
+    = button_tag type: :submit, class: 'btn btn-success' do
+      => fa_icon 'plus'
+      | Create
+
+  h3.mt-4 Players
   - @players.each do |player|
     = simple_form_for player, url: tournament_player_path(@tournament, player), html: { class: 'form-inline mb-2 identities_form' } do |f|
       => f.text_field :name, class: 'form-control mr-2'
@@ -20,17 +32,6 @@
       =< link_to tournament_player_path(@tournament, player), method: :delete, class: 'btn btn-danger mr-2' do
         => fa_icon 'trash'
         | Delete
-
-  h3.mt-4 Register player
-  = simple_form_for :player, url: tournament_players_path(@tournament), html: { class: 'form-inline identities_form' } do |f|
-    => f.text_field :name, placeholder: 'Name', class: 'form-control mr-2'
-    => f.text_field :corp_identity, placeholder: 'Corporation', class: 'corp_identities form-control mr-2'
-    => f.text_field :runner_identity, placeholder: 'Runner', class: 'runner_identities form-control mr-2'
-    .form-check.mr-2
-      => f.input_field :first_round_bye, as: :boolean, inline_label: 'First round bye?', class: 'form-check-input'
-    = button_tag type: :submit, class: 'btn btn-success' do
-      => fa_icon 'plus'
-      | Create
 
   - if @dropped.any?
     h3.mt-4 Dropped

--- a/app/views/players/standings/_swiss.html.slim
+++ b/app/views/players/standings/_swiss.html.slim
@@ -9,12 +9,13 @@ table.table.table-striped.standings
       th SOS
       th Extended SOS
   tbody
+    - tournament_started = stage.rounds.complete.any?
     - standings.each_with_index do |standing, i|
       tr
         td= i+1
         td= standing.name
         td.ids
-          - if stage.rounds.complete.any?
+          - if tournament_started
             = render standing.corp_identity
             = render standing.runner_identity
           - else

--- a/app/views/rounds/_pairings.html.slim
+++ b/app/views/rounds/_pairings.html.slim
@@ -1,9 +1,10 @@
+- single_sided = round.stage.single_sided?
 - round.pairings.each do |pairing|
   .row.m-1.round_pairing class="table_#{pairing.table_number} #{'reported' if pairing.reported?}"
     .col-sm-2 Table #{pairing.table_number}
     .col-sm.left_player_name
-      = pairing.player1.name
-      =< render 'player_side', pairing: pairing, player: pairing.player1
+      = @players[pairing.player1_id].name
+      =< render 'player_side', pairing: pairing, player: @players[pairing.player1_id], single_sided: single_sided
     .col-sm-3.centre_score
       - if policy(round.tournament).edit?
         .preset_score
@@ -22,8 +23,8 @@
       - else
         | #{pairing.score1} - #{pairing.score2}
     .col-sm.right_player_name
-      = pairing.player2.name
-      =< render 'player_side', pairing: pairing, player: pairing.player2
+      = @players[pairing.player2_id].name
+      =< render 'player_side', pairing: pairing, player: @players[pairing.player2_id], single_sided: single_sided
     - if policy(round.tournament).update?
       .col-sm-1
         = link_to tournament_round_pairing_path(round.tournament, round, pairing), method: :delete, class: 'btn btn-danger', data: { confirm: 'Are you sure? This cannot be reversed.' } do

--- a/app/views/rounds/_player_side.html.slim
+++ b/app/views/rounds/_player_side.html.slim
@@ -1,4 +1,4 @@
-- if pairing.stage.single_sided?
+- if single_sided
   - if policy(pairing.tournament).update?
     = set_side_button(player, :corp, pairing)
     = set_side_button(player, :runner, pairing)

--- a/app/views/rounds/_round.html.slim
+++ b/app/views/rounds/_round.html.slim
@@ -1,26 +1,27 @@
-.card
-  .card-header role="tab"
-    .row
-      .col-sm-9
-        a data-toggle="collapse" href="#round#{round.id}"
-          h5.mb-0 Round #{round.number}
-      .col-sm-3
-        | #{round.pairings.reported.count} / #{round.pairings.count} pairings reported
+- if round.stage.players.count < 100 || round == @tournament.stages.last.rounds.last
+  .card
+    .card-header role="tab"
+      .row
+        .col-sm-9
+          a data-toggle="collapse" href="#round#{round.id}"
+            h5.mb-0 Round #{round.number}
+        .col-sm-3
+          | #{round.pairings.reported.count} / #{round.pairings.count} pairings reported
 
-  .collapse id="round#{round.id}" class=("show" if round == @tournament.stages.last.rounds.last)
-    .col-12.my-3
-      - if policy(round.tournament).edit?
-        = link_to tournament_round_path(round.tournament, round), class: 'btn btn-warning' do
-          => fa_icon 'pencil'
-          | Edit
-        - unless round.completed?
-          =< link_to complete_tournament_round_path(round.tournament, round, completed: true), method: :patch, class: 'btn btn-warning' do
-            => fa_icon 'check'
-            | Complete
-        =< link_to match_slips_tournament_round_pairings_path(round.tournament, round), class: 'btn btn-primary' do
-          => fa_icon 'flag-checkered'
-          | Match slips
-      =< link_to tournament_round_pairings_path(round.tournament, round), class: 'btn btn-primary' do
-        => fa_icon 'list-ul'
-        | Pairings by name
-      = render 'pairings', round: round
+    .collapse id="round#{round.id}" class=("show" if round == @tournament.stages.last.rounds.last)
+      .col-12.my-3
+        - if policy(round.tournament).edit?
+          = link_to tournament_round_path(round.tournament, round), class: 'btn btn-warning' do
+            => fa_icon 'pencil'
+            | Edit
+          - unless round.completed?
+            =< link_to complete_tournament_round_path(round.tournament, round, completed: true), method: :patch, class: 'btn btn-warning' do
+              => fa_icon 'check'
+              | Complete
+          =< link_to match_slips_tournament_round_pairings_path(round.tournament, round), class: 'btn btn-primary' do
+            => fa_icon 'flag-checkered'
+            | Match slips
+        =< link_to tournament_round_pairings_path(round.tournament, round), class: 'btn btn-primary' do
+          => fa_icon 'list-ul'
+          | Pairings by name
+        = render 'pairings', round: round

--- a/app/views/rounds/index.html.slim
+++ b/app/views/rounds/index.html.slim
@@ -5,6 +5,12 @@
         => fa_icon 'plus'
         | Add Swiss stage
   - else
+    - if policy(@tournament).update?
+      p
+        #toggle_reported.btn.btn-primary
+          => fa_icon 'eye-slash'
+          | Show/hide reported pairings
+      .reported_hidden_message.alert.alert-info Reported scores are currently hidden on this page. This will not affect other users viewing this page.
     - if @tournament.rounds.empty?
       p= link_to meeting_tournament_players_path(@tournament), class: 'btn btn-primary' do
         => fa_icon 'list-ul'

--- a/app/views/rounds/show.html.slim
+++ b/app/views/rounds/show.html.slim
@@ -4,23 +4,24 @@
     => link_to tournament_rounds_path(@round.tournament), class: 'btn btn-primary' do
       => fa_icon 'arrow-left'
       | Back to pairings
-    => link_to repair_tournament_round_path(@round.tournament, @round), method: :patch, class: 'btn btn-warning', data: { confirm: 'Are you sure? This cannot be reversed.' } do
-      => fa_icon 'refresh'
-      | Re-pair
-    - if @round.completed?
-      => link_to complete_tournament_round_path(@round.tournament, @round, completed: false), method: :patch, class: 'btn btn-warning' do
-        => fa_icon 'backward'
-        | Uncomplete
-    - else
-      => link_to complete_tournament_round_path(@round.tournament, @round, completed: true), method: :patch, class: 'btn btn-warning' do
-        => fa_icon 'check'
-        | Complete
-    => link_to edit_tournament_round_path(@round.tournament, @round), class: 'btn btn-warning' do
-      => fa_icon 'wrench'
-      | Advanced
-    = link_to tournament_round_path(@round.tournament, @round), method: :delete, class: 'btn btn-danger', data: { confirm: 'Are you sure? This cannot be reversed.' } do
-      => fa_icon 'trash'
-      | Delete round
+    - if policy(@round.tournament).update?
+      => link_to repair_tournament_round_path(@round.tournament, @round), method: :patch, class: 'btn btn-warning', data: { confirm: 'Are you sure? This cannot be reversed.' } do
+        => fa_icon 'refresh'
+        | Re-pair
+      - if @round.completed?
+        => link_to complete_tournament_round_path(@round.tournament, @round, completed: false), method: :patch, class: 'btn btn-warning' do
+          => fa_icon 'backward'
+          | Uncomplete
+      - else
+        => link_to complete_tournament_round_path(@round.tournament, @round, completed: true), method: :patch, class: 'btn btn-warning' do
+          => fa_icon 'check'
+          | Complete
+      => link_to edit_tournament_round_path(@round.tournament, @round), class: 'btn btn-warning' do
+        => fa_icon 'wrench'
+        | Advanced
+      = link_to tournament_round_path(@round.tournament, @round), method: :delete, class: 'btn btn-danger', data: { confirm: 'Are you sure? This cannot be reversed.' } do
+        => fa_icon 'trash'
+        | Delete round
   = render 'pairings', round: @round
 
 h3.mt-2.col-12 Unpaired players

--- a/spec/feature/players/list_players_spec.rb
+++ b/spec/feature/players/list_players_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Listing players' do
     end
 
     it 'lists players' do
-      expect(first('input[name="player[name]"]').value).to eq('Jack Player')
+      expect(all('input[name="player[name]"]').last.value).to eq('Jack Player')
     end
   end
 

--- a/spec/feature/players/update_players_spec.rb
+++ b/spec/feature/players/update_players_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'updating players' do
 
     sign_in tournament.user
     visit tournament_players_path(tournament)
-    within(first('form')) do
+    within(all('form').last) do
       fill_in :player_name, with: 'Jill Player'
       fill_in :player_corp_identity, with: 'Jinteki: Personal Evolution'
       fill_in :player_runner_identity, with: 'Gabriel Santiago'

--- a/spec/load_test.rb
+++ b/spec/load_test.rb
@@ -1,6 +1,6 @@
 RSpec.describe 'load testing' do
   ROUNDS = 10
-  PLAYERS = 150
+  PLAYERS = 200
 
   let(:tournament) { create(:tournament) }
 
@@ -12,21 +12,27 @@ RSpec.describe 'load testing' do
 
   it 'can handle load' do
     timer
+    sign_in tournament.user
     puts 'Creating players'
     PLAYERS.times { create(:player, tournament: tournament) }
     puts "\tDone. Took #{timer} seconds"
     ROUNDS.times do |i|
-      puts "Creating and pairing round #{i+1}"
+      puts "Round #{i+1}"
+      puts "\tPairing #{tournament.players.active.count} players"
       round = tournament.pair_new_round!
-      puts "\tDone. Took #{timer} seconds"
-      puts 'Generating results'
+      puts "\t\tDone. Took #{timer} seconds"
+      puts "\tGenerating results"
       round.pairings.each do |p|
+        # visit tournament_rounds_path(tournament)
         p.update(score1: rand(0..6), score2: rand(0..6))
       end
-      puts "\tDone. Took #{timer} seconds"
+      expect(round.pairings.map(&:players).flatten.map(&:id) - [nil]).to match_array(tournament.players.active.map(&:id))
+      tournament.players.active.shuffle.take(3).each { |p| p.update(active: false) }
+      round.update(completed: true)
+      puts "\t\tDone. Took #{timer} seconds"
+      puts "\tCalculating standings"
+      visit standings_tournament_players_path(tournament)
+      puts "\t\tDone. Took #{timer} seconds"
     end
-    puts 'Calculating standings'
-    tournament.standings.players #calculate standings to test, we don't need them
-    puts "\tDone. Took #{timer} seconds"
   end
 end

--- a/spec/services/pairing_strategies/swiss_spec.rb
+++ b/spec/services/pairing_strategies/swiss_spec.rb
@@ -64,9 +64,12 @@ RSpec.describe PairingStrategies::Swiss do
     end
 
     context 'after some rounds' do
+      let(:round1) { create(:round, number: 1, stage: stage) }
+      let(:round) { create(:round, number: 2, stage: stage) }
+
       before do
-        create(:pairing, player1: jack, player2: jill, score1: 6, score2: 0)
-        create(:pairing, player1: hansel, player2: gretel, score1: 4, score2: 1)
+        create(:pairing, player1: jack, player2: jill, score1: 6, score2: 0, round: round1)
+        create(:pairing, player1: hansel, player2: gretel, score1: 4, score2: 1, round: round1)
       end
 
       it 'pairs based on points' do
@@ -125,10 +128,13 @@ RSpec.describe PairingStrategies::Swiss do
     end
 
     context 'after multiple rounds' do
+      let(:round1) { create(:round, number: 1, stage: stage) }
+      let(:round) { create(:round, number: 2, stage: stage) }
+
       before do
-        create(:pairing, player1: snap, score1: 6)
-        create(:pairing, player1: crackle, score1: 3)
-        create(:pairing, player1: pop, player2: nil, score1: 1, score2: 0)
+        create(:pairing, player1: snap, score1: 6, round: round1)
+        create(:pairing, player1: crackle, score1: 3, round: round1)
+        create(:pairing, player1: pop, player2: nil, score1: 1, score2: 0, round: round1)
       end
 
       it 'avoids previous byes' do


### PR DESCRIPTION
Tournaments that have over 100 players will have some slight tweaks:
To reduce page load, the pairings page will only show the current
round.
Swiss pairing cheats a little. The field is split into two halves
and each is paired independently. This avoids the calculation
getting exponentially slower. The top half will always be an even
number so any bye will in the bottom half. This should not affect
pairing of players at the very top of the field.

Also added the ability to hide reported scores for the tournament
owner to make result entry easier.