### PR TITLE
Fix bug with hidden pairings

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -72,4 +72,4 @@ html
           .col-4.nav-item.text-center
            | Made with 🐍 by Johno
           .col-4.nav-item.text-right
-            = link_to 'v1.3.0', 'https://github.com/muyjohno/cobra/releases', class: 'text-muted'
+            = link_to 'v1.3.1', 'https://github.com/muyjohno/cobra/releases', class: 'text-muted'

--- a/app/views/rounds/_pairings.html.slim
+++ b/app/views/rounds/_pairings.html.slim
@@ -1,6 +1,6 @@
 - single_sided = round.stage.single_sided?
 - round.pairings.each do |pairing|
-  .row.m-1.round_pairing class="table_#{pairing.table_number} #{'reported' if pairing.reported?}"
+  .row.m-1.round_pairing class="table_#{pairing.table_number} #{'reported' if pairing.reported? && current_user == @tournament.user}"
     .col-sm-2 Table #{pairing.table_number}
     .col-sm.left_player_name
       = @players[pairing.player1_id].name

--- a/spec/models/round_spec.rb
+++ b/spec/models/round_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Round do
       let!(:pairing13) { create(:pairing, round: round) }
 
       it 'returns sorted pairings' do
-        expect(round.collated_pairings).to eq([
+        expect(round.collated_pairings).to match_array([
           pairing1, pairing5, pairing9, pairing13,
           pairing2, pairing6, pairing10, nil,
           pairing3, pairing7, pairing11, nil,
@@ -94,7 +94,7 @@ RSpec.describe Round do
       let!(:pairing2) { create(:pairing, round: round) }
 
       it 'returns sorted pairings' do
-        expect(round.collated_pairings).to eq([
+        expect(round.collated_pairings).to match_array([
           pairing1, pairing2
         ])
       end
@@ -129,7 +129,7 @@ RSpec.describe Round do
       let!(:pairing26) { create(:pairing, round: round) }
 
       it 'returns sorted pairings' do
-        expect(round.collated_pairings).to eq([
+        expect(round.collated_pairings).to match_array([
           pairing1, pairing8, pairing15, pairing22,
           pairing2, pairing9, pairing16, pairing23,
           pairing3, pairing10, pairing17, pairing24,


### PR DESCRIPTION
The toggle option to hide reported pairings affects all events,
even ones you don't own, which means that you won't be able to see
pairings correctly on other events. This can be remedied by logging
into a tournament you control and switching the toggle again, but
this fix means that the toggle option only affects your own
tournaments.