### PR TITLE
Fix match slip print padding issue

### DIFF
--- a/app/assets/stylesheets/global.sass
+++ b/app/assets/stylesheets/global.sass
@@ -46,6 +46,9 @@ nav.navbar, .footer
   .container
     width: auto
 
+  .main-content
+    padding-top: 0 !important
+
   .dontprint
     display: none !important
 

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -60,7 +60,7 @@ html
         .row.py-3
           .col-12
             .alert.alert-danger= alert
-      .row.py-3
+      .row.py-3.main-content
         = yield
     .footer.dontprint
       .container
@@ -72,4 +72,4 @@ html
           .col-4.nav-item.text-center
            | Made with 🐍 by Johno
           .col-4.nav-item.text-right
-            = link_to 'v1.3.1', 'https://github.com/muyjohno/cobra/releases', class: 'text-muted'
+            = link_to 'v1.3.2', 'https://github.com/muyjohno/cobra/releases', class: 'text-muted'


### PR DESCRIPTION
Fixed a very minor issue where the first page of match slips didn't
line up with other pages when printed.