### PR TITLE
Apply high table numbers to byes

### DIFF
--- a/app/services/pairing_strategies/swiss.rb
+++ b/app/services/pairing_strategies/swiss.rb
@@ -27,10 +27,10 @@ module PairingStrategies
     end
 
     def paired_players
-      return players_to_pair.to_a.shuffle.in_groups_of(2, Swissper::Bye) if first_round?
-      return PairingStrategies::BigSwiss.new(stage).pair! if players.count > 60
+      return @paired_players ||= players_to_pair.to_a.shuffle.in_groups_of(2, Swissper::Bye) if first_round?
+      return @paired_players ||= PairingStrategies::BigSwiss.new(stage).pair! if players.count > 60
 
-      Swissper.pair(
+      @paired_players ||= Swissper.pair(
         players_to_pair.to_a,
         delta_key: :points,
         exclude_key: :unpairable_opponents
@@ -57,8 +57,13 @@ module PairingStrategies
     end
 
     def apply_numbers!(sorter)
-      sorter.sort(round.pairings).each_with_index do |pairing, i|
+      sorter.sort(round.pairings.non_bye).each_with_index do |pairing, i|
         pairing.update(table_number: i + 1)
+      end
+
+      non_bye_tables = round.pairings.non_bye.count
+      round.pairings.bye.each_with_index do |pairing, i|
+        pairing.update(table_number: i + non_bye_tables + 1)
       end
     end
 

--- a/spec/services/pairing_strategies/swiss_spec.rb
+++ b/spec/services/pairing_strategies/swiss_spec.rb
@@ -42,6 +42,14 @@ RSpec.describe PairingStrategies::Swiss do
         end
       end
 
+      it 'gives byes highest table numbers' do
+        pairer.pair!
+
+        round.reload
+
+        expect(round.pairings.bye.pluck(:table_number)).to match_array([2, 3])
+      end
+
       context 'in second round' do
         let(:round2_pairer) { described_class.new(round2) }
         let(:round2) { create(:round, number: 2, stage: stage) }
@@ -115,6 +123,14 @@ RSpec.describe PairingStrategies::Swiss do
       ).to contain_exactly(snap, crackle, pop, nil_player)
     end
 
+    it 'gives bye highest table number' do
+      pairer.pair!
+
+      round.reload
+
+      expect(round.pairings.bye.first.table_number).to eq(round.pairings.count)
+    end
+
     it 'gives win against bye' do
       pairer.pair!
 
@@ -132,8 +148,7 @@ RSpec.describe PairingStrategies::Swiss do
       let(:round) { create(:round, number: 2, stage: stage) }
 
       before do
-        create(:pairing, player1: snap, score1: 6, round: round1)
-        create(:pairing, player1: crackle, score1: 3, round: round1)
+        create(:pairing, player1: snap, score1: 6, player2: crackle, score2: 3, round: round1)
         create(:pairing, player1: pop, player2: nil, score1: 1, score2: 0, round: round1)
       end
 
@@ -145,6 +160,14 @@ RSpec.describe PairingStrategies::Swiss do
         round.pairings.each do |pairing|
           expect(pairing.players).not_to match_array([pop, nil_player]) if pairing.players.include? pop
         end
+      end
+
+      it 'gives bye highest table number' do
+        pairer.pair!
+
+        round.reload
+
+        expect(round.pairings.bye.first.table_number).to eq(round.pairings.count)
       end
     end
 


### PR DESCRIPTION
Previously byes have been created first and as a quirk of this have
had low table numbers in the first round, which is confusing and
inconvenient for TOs.

This change specifically numbers non-byes before byes such that byes
should always have the highest table numbers.