### PR TITLE
Display scoop on home page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ config/secrets.yml
 # Ignore db for sqlite
 cobra
 cobra_test
+
+public/scoop.png

--- a/app/views/home/home.html.slim
+++ b/app/views/home/home.html.slim
@@ -18,3 +18,7 @@
     p= link_to tournaments_path, class: 'btn btn-primary' do
       => fa_icon 'users'
       | More tournaments
+
+- if File.exists?(Rails.root.join('public', 'scoop.png'))
+  .col-12.text-center
+    = image_tag '/scoop.png'

--- a/config/version.yml
+++ b/config/version.yml
@@ -1,1 +1,1 @@
-version: 1.5.0
+version: 1.5.1


### PR DESCRIPTION
When a scoop image has been uploaded, display it on the home page.