### PR TITLE
Add player identities to pairings page

### DIFF
--- a/app/assets/javascripts/pairings.js.coffee
+++ b/app/assets/javascripts/pairings.js.coffee
@@ -8,7 +8,18 @@ $(document).on 'turbolinks:load', ->
   else
     localStorage['hide_reported'] = false
     $('.reported_hidden_message').hide()
+
   $('#toggle_reported').on 'click', (e) ->
     $('.reported').toggle()
     $('.reported_hidden_message').toggle()
     localStorage['hide_reported'] = !JSON.parse(localStorage['hide_reported'])
+
+  if localStorage['show_identities'] && JSON.parse(localStorage['show_identities'])
+    $('.round_pairing .ids').show()
+  else
+    localStorage['show_identities'] = false
+    $('.round_pairing .ids').hide()
+
+  $('#toggle_identities').on 'click', (e) ->
+    $('.round_pairing .ids').toggle()
+    localStorage['show_identities'] = !JSON.parse(localStorage['show_identities'])

--- a/app/assets/stylesheets/pairings.sass
+++ b/app/assets/stylesheets/pairings.sass
@@ -18,5 +18,10 @@
     .preset_score
       display: none
 
+  .ids
+    display: none
+    font-size: 0.6em
+    line-height: 1.4em
+
 .match_slip
   min-height: 220px

--- a/app/models/nil_player.rb
+++ b/app/models/nil_player.rb
@@ -22,4 +22,12 @@ class NilPlayer
   def points
     0
   end
+
+  def corp_identity_object
+    nil
+  end
+
+  def runner_identity_object
+    nil
+  end
 end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -52,6 +52,14 @@ class Player < ApplicationRecord
     pairings.bye.any?
   end
 
+  def corp_identity_object
+    Identity.find_or_initialize_by(name: corp_identity)
+  end
+
+  def runner_identity_object
+    Identity.find_or_initialize_by(name: runner_identity)
+  end
+
   private
 
   def destroy_pairings

--- a/app/services/standing.rb
+++ b/app/services/standing.rb
@@ -20,16 +20,10 @@ class Standing
   end
 
   def corp_identity
-    identity(player.corp_identity)
+    player.corp_identity_object
   end
 
   def runner_identity
-    identity(player.runner_identity)
-  end
-
-  private
-
-  def identity(id)
-    Identity.find_or_initialize_by(name: id)
+    player.runner_identity_object
   end
 end

--- a/app/views/rounds/_pairings.html.slim
+++ b/app/views/rounds/_pairings.html.slim
@@ -5,6 +5,10 @@
     .col-sm.left_player_name
       = @players[pairing.player1_id].name
       =< render 'player_side', pairing: pairing, player: @players[pairing.player1_id], single_sided: single_sided
+      - if @players[pairing.player1_id].id
+        .ids
+          = render @players[pairing.player1_id].corp_identity_object
+          = render @players[pairing.player1_id].runner_identity_object
     - if policy(round.tournament).edit?
       .col-sm-5.centre_score
         .preset_score
@@ -30,6 +34,10 @@
     .col-sm.right_player_name
       = @players[pairing.player2_id].name
       =< render 'player_side', pairing: pairing, player: @players[pairing.player2_id], single_sided: single_sided
+      - if @players[pairing.player2_id].id
+        .ids
+          = render @players[pairing.player2_id].corp_identity_object
+          = render @players[pairing.player2_id].runner_identity_object
     - if policy(round.tournament).update?
       .col-sm-1
         = link_to tournament_round_pairing_path(round.tournament, round, pairing), method: :delete, class: 'btn btn-danger', data: { confirm: 'Are you sure? This cannot be reversed.' } do

--- a/app/views/rounds/index.html.slim
+++ b/app/views/rounds/index.html.slim
@@ -15,6 +15,11 @@
       p= link_to meeting_tournament_players_path(@tournament), class: 'btn btn-primary' do
         => fa_icon 'list-ul'
         | Player meeting
+    - else
+      p
+        #toggle_identities.btn.btn-primary
+          => fa_icon 'eye-slash'
+          | Show/hide identities
 
     = render @tournament.stages
 


### PR DESCRIPTION
Player identities can now be listed on the pairings page. They are
toggleable by the viewer. Toggle choice will be persisted across page
loads in localStorage.