### PR TITLE
Sort players by name sanely

### DIFF
--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -5,8 +5,8 @@ class PlayersController < ApplicationController
   def index
     authorize @tournament, :update?
 
-    @players = @tournament.players.active.sort_by { |p| p.name || '' }
-    @dropped = @tournament.players.dropped.sort_by { |p| p.name || '' }
+    @players = @tournament.players.active.sort_by { |p| p.name.downcase || '' }
+    @dropped = @tournament.players.dropped.sort_by { |p| p.name.downcase || '' }
   end
 
   def create

--- a/app/views/players/meeting.html.slim
+++ b/app/views/players/meeting.html.slim
@@ -12,7 +12,7 @@
         th Player 1
         th Player 2
     tbody
-      - @tournament.players.sort_by(&:name).map(&:name).in_groups_of(2).each_with_index do |pairing, i|
+      - @tournament.players.map(&:name).sort_by{ |n| n.downcase }.in_groups_of(2).each_with_index do |pairing, i|
         tr
           td= i+1
           td= pairing[0]

--- a/spec/feature/players/list_players_spec.rb
+++ b/spec/feature/players/list_players_spec.rb
@@ -14,9 +14,24 @@ RSpec.describe 'Listing players' do
     it 'lists players' do
       expect(all('input[name="player[name]"]').last.value).to eq('Jack Player')
     end
+
+    context 'with multiple players' do
+      before do
+        tournament.players << create(:player, name: 'adam')
+        tournament.players << create(:player, name: 'Ben')
+
+        visit tournament_players_path(tournament)
+      end
+
+      it 'sorts players' do
+        expect(all('input[name="player[name]"]').map(&:value)).to eq(
+          [nil, 'adam', 'Ben', 'Jack Player']
+        )
+      end
+    end
   end
 
-  context 'as owner' do
+  context 'as non-owner' do
     before do
       sign_in create(:user)
       visit tournament_players_path(tournament)

--- a/spec/feature/players/show_player_meeting_spec.rb
+++ b/spec/feature/players/show_player_meeting_spec.rb
@@ -1,12 +1,13 @@
 RSpec.describe 'show player meeting' do
   let(:tournament) { create(:tournament) }
-  let!(:jack) { create(:player, name: 'Jack', tournament: tournament) }
-  let!(:jill) { create(:player, name: 'Jill', tournament: tournament) }
-  let!(:snap) { create(:player, name: 'Snap', tournament: tournament) }
-  let!(:crackle) { create(:player, name: 'Crackle', tournament: tournament) }
-  let!(:pop) { create(:player, name: 'Pop', tournament: tournament) }
 
   it 'displays meeting pairings' do
+    create(:player, name: 'Jack', tournament: tournament)
+    create(:player, name: 'Jill', tournament: tournament)
+    create(:player, name: 'Snap', tournament: tournament)
+    create(:player, name: 'Crackle', tournament: tournament)
+    create(:player, name: 'Pop', tournament: tournament)
+
     sign_in tournament.user
     visit tournament_players_path(tournament)
     click_link 'Player meeting'
@@ -18,4 +19,19 @@ RSpec.describe 'show player meeting' do
     end
   end
 
+  it 'sorts player names correctly' do
+    create(:player, name: 'alan', tournament: tournament)
+    create(:player, name: 'Ben', tournament: tournament)
+    create(:player, name: 'callum', tournament: tournament)
+    create(:player, name: 'David', tournament: tournament)
+
+    sign_in tournament.user
+    visit tournament_players_path(tournament)
+    click_link 'Player meeting'
+
+    aggregate_failures do
+      expect(page).to have_content('1alanBen')
+      expect(page).to have_content('2callumDavid')
+    end
+  end
 end


### PR DESCRIPTION
Players are sorted by name in two places: the player index (visible
only to TOs) and the player meeting pairings (visible to all), but
the order sorted case-sensitively, which is unintuitive.

This change fixes the sorting in those two places to sort case-
insensitively.

Fixes/implements #118