### PR TITLE
Display info about winning sides

### DIFF
--- a/app/helpers/pairings_helper.rb
+++ b/app/helpers/pairings_helper.rb
@@ -82,4 +82,27 @@ module PairingsHelper
   def player_is_in_pairing(player, pairing)
     pairing.player1_id == player.id || pairing.player2_id == player.id
   end
+
+  def readable_score(pairing)
+    return "-" if pairing.score1 == 0 && pairing.score2 == 0
+    ws = winning_side(pairing)
+
+    return "#{pairing.score1} - #{pairing.score2}" unless ws
+
+    "#{pairing.score1} - #{pairing.score2} (#{ws})"
+  end
+
+  def winning_side(pairing)
+    corp_score = (pairing.score1_corp || 0) + (pairing.score2_corp || 0)
+    runner_score = (pairing.score1_runner || 0) + (pairing.score2_runner || 0)
+
+    case
+    when corp_score - runner_score == 0
+      nil
+    when corp_score - runner_score < 0
+      'R'
+    else
+      'C'
+    end
+  end
 end

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -43,7 +43,9 @@ class Stage < ApplicationRecord
         player: standing.player,
         points: standing.points,
         sos: standing.sos,
-        extended_sos: standing.extended_sos
+        extended_sos: standing.extended_sos,
+        corp_points: standing.corp_points,
+        runner_points: standing.runner_points
       )
     end
   end

--- a/app/services/sos_calculator.rb
+++ b/app/services/sos_calculator.rb
@@ -7,6 +7,8 @@ class SosCalculator
     games_played = {}
     opponents = {}
     points_for_sos = {}
+    corp_points = {}
+    runner_points = {}
     stage.eligible_pairings.each do |p|
       points[p.player1_id] ||= 0
       points[p.player1_id] += p.score1 || 0
@@ -24,6 +26,14 @@ class SosCalculator
       points_for_sos[p.player1_id] += p.score1 || 0
       points_for_sos[p.player2_id] ||= 0
       points_for_sos[p.player2_id] += p.score2 || 0
+      corp_points[p.player1_id] ||= 0
+      corp_points[p.player1_id] += p.score1_corp || 0
+      corp_points[p.player2_id] ||= 0
+      corp_points[p.player2_id] += p.score2_corp || 0
+      runner_points[p.player1_id] ||= 0
+      runner_points[p.player1_id] += p.score1_runner || 0
+      runner_points[p.player2_id] ||= 0
+      runner_points[p.player2_id] += p.score2_runner || 0
     end
 
     # filter out byes from sos calculations
@@ -57,7 +67,9 @@ class SosCalculator
       Standing.new(p,
         points: points[p.id],
         sos: sos[p.id],
-        extended_sos: extended_sos[p.id]
+        extended_sos: extended_sos[p.id],
+        corp_points: corp_points[p.id],
+        runner_points: runner_points[p.id]
       )
     end.sort
   end

--- a/app/services/standing.rb
+++ b/app/services/standing.rb
@@ -1,5 +1,5 @@
 class Standing
-  attr_reader :player, :points, :sos, :extended_sos
+  attr_reader :player, :points, :sos, :extended_sos, :corp_points, :runner_points
 
   delegate :name, :corp_identity, :runner_identity, to: :player
   delegate :seed_in_stage, to: :player
@@ -9,6 +9,8 @@ class Standing
     @points = values.fetch(:points, 0) || 0
     @sos = values.fetch(:sos, 0) || 0
     @extended_sos = values.fetch(:extended_sos, 0) || 0
+    @corp_points = values.fetch(:corp_points, 0) || 0
+    @runner_points = values.fetch(:runner_points, 0) || 0
   end
 
   def <=>(other)

--- a/app/views/identities/_identity.html.slim
+++ b/app/views/identities/_identity.html.slim
@@ -1,3 +1,6 @@
 .div class="#{identity.faction}"
   i.fa.icon class="icon-#{identity.faction}"
   =< identity.name
+  - if local_assigns[:points]
+    = side if identity.name.empty? && local_assigns[:side]
+    = " (#{points})"

--- a/app/views/players/standings/_swiss.html.slim
+++ b/app/views/players/standings/_swiss.html.slim
@@ -15,8 +15,8 @@ table.table.table-striped.standings
           td= row.position
           td= row.name
           td.ids
-            = render row.corp_identity
-            = render row.runner_identity
+            = render row.corp_identity, points: row.corp_points, side: 'Corp'
+            = render row.runner_identity, points: row.runner_points, side: 'Runner'
           td= row.points
           td= number_with_precision row.sos, precision: 4
           td= number_with_precision row.extended_sos, precision: 4

--- a/app/views/rounds/_pairings.html.slim
+++ b/app/views/rounds/_pairings.html.slim
@@ -30,7 +30,7 @@
               =< link_to '...', '#', class: 'btn btn-primary toggle_custom_score'
     - else
       .col-sm-2.centre_score
-        | #{pairing.score1} - #{pairing.score2}
+        = readable_score(pairing)
     .col-sm.right_player_name
       = @players[pairing.player2_id].name
       =< render 'player_side', pairing: pairing, player: @players[pairing.player2_id], single_sided: single_sided

--- a/db/migrate/20200618191437_add_side_points_to_standing_rows.rb
+++ b/db/migrate/20200618191437_add_side_points_to_standing_rows.rb
@@ -1,0 +1,6 @@
+class AddSidePointsToStandingRows < ActiveRecord::Migration[5.2]
+  def change
+    add_column :standing_rows, :corp_points, :integer
+    add_column :standing_rows, :runner_points, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_18_152800) do
+ActiveRecord::Schema.define(version: 2020_06_18_191437) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -94,6 +94,8 @@ ActiveRecord::Schema.define(version: 2020_06_18_152800) do
     t.integer "points"
     t.decimal "sos"
     t.decimal "extended_sos"
+    t.integer "corp_points"
+    t.integer "runner_points"
     t.index ["player_id"], name: "index_standing_rows_on_player_id"
     t.index ["stage_id"], name: "index_standing_rows_on_stage_id"
   end

--- a/spec/helpers/pairings_helper_spec.rb
+++ b/spec/helpers/pairings_helper_spec.rb
@@ -104,4 +104,26 @@ RSpec.describe PairingsHelper do
       end
     end
   end
+
+  describe '#readable_score' do
+    let(:sweep) { create(:pairing, score1_corp: 3, score1_runner: 3)}
+    let(:runner_split) { create(:pairing, score1_runner: 3, score2_runner: 3) }
+    let(:corp_split) { create(:pairing, score1_corp: 3, score2_corp: 3) }
+    let(:swept) { create(:pairing, score2_corp: 3, score2_runner: 3) }
+    let(:unreported) { create(:pairing) }
+    let(:unusual) { create(:pairing, score1_corp: 3, score1_runner: 1, score2_corp: 1) }
+    let(:undeclared_sides) { create(:pairing, score1: 3, score2: 3) }
+
+    it 'outputs correct score description' do
+      aggregate_failures do
+        expect(helper.readable_score(sweep)).to eq('6 - 0')
+        expect(helper.readable_score(runner_split)).to eq('3 - 3 (R)')
+        expect(helper.readable_score(corp_split)).to eq('3 - 3 (C)')
+        expect(helper.readable_score(swept)).to eq('0 - 6')
+        expect(helper.readable_score(unreported)).to eq('-')
+        expect(helper.readable_score(unusual)).to eq('4 - 1 (C)')
+        expect(helper.readable_score(undeclared_sides)).to eq('3 - 3')
+      end
+    end
+  end
 end

--- a/spec/models/stage_spec.rb
+++ b/spec/models/stage_spec.rb
@@ -111,8 +111,8 @@ RSpec.describe Stage do
     it 'generates standing row entries' do
       stage.players << jack
       stage.players << jill
-      report round1, 1, jack, 6, jill, 0
-      report round2, 1, jack, 3, jill, 3
+      create(:pairing, round: round1, player1: jack, player2: jill, score1_corp: 3, score1_runner: 3)
+      create(:pairing, round: round2, player1: jack, player2: jill, score1_corp: 3, score2_corp: 3)
 
       expect do
         stage.cache_standings!
@@ -123,6 +123,8 @@ RSpec.describe Stage do
       expect(stage.standing_rows.map(&:points)).to eq([6, 0])
       expect(stage.standing_rows.map(&:sos)).to eq([0, 6])
       expect(stage.standing_rows.map(&:extended_sos)).to eq([6, 0])
+      expect(stage.standing_rows.map(&:corp_points)).to eq([3, 0])
+      expect(stage.standing_rows.map(&:runner_points)).to eq([3, 0])
     end
   end
 end

--- a/spec/services/sos_calculator_spec.rb
+++ b/spec/services/sos_calculator_spec.rb
@@ -146,4 +146,18 @@ RSpec.describe SosCalculator do
       end
     end
   end
+
+  describe 'corp and runner points' do
+    before do
+      create(:pairing, player1: snap, player2: crackle, score1_corp: 3, score1_runner: 3, round: round)
+      create(:pairing, player1: snap, player2: pop, score1_corp: 1, score2_corp: 3, round: round)
+    end
+
+    it 'calculates side points' do
+      aggregate_failures do
+        expect(standing.corp_points).to eq(4)
+        expect(standing.runner_points).to eq(3)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Pairings will now display the winning side if it's known, e.g. a
corp split will be reported as '3 - 3 (C)'.

Standings will now display the total points accumulated for each
side next to the identities.