### PR TITLE
Fix bug with empty string for stream URL

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -38,7 +38,7 @@ html
           .col-10
             h1= @tournament.name
           .col-2.text-right
-            - if @tournament.stream_url
+            - if @tournament.stream_url.present?
               = link_to @tournament.stream_url, class: 'stream-link', target: '_blank' do
                 => fa_icon 'video-camera'
         ul.nav.nav-tabs.dontprint

--- a/spec/feature/tournaments/view_tournament_spec.rb
+++ b/spec/feature/tournaments/view_tournament_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe 'viewing a tournament' do
 
     describe 'stream link' do
       it 'does not display link if no stream url is set' do
+        tournament.update(stream_url: '')
+
+        visit tournament_path(tournament)
+
         expect(page.body).not_to include('video-camera')
       end
 


### PR DESCRIPTION
This change fixes a bug that causes the stream link icon to appear
all the time, due to the truthiness of an empty string.