### PR TITLE
Fix bug with incorrect stream icon on tournament list

### DIFF
--- a/app/views/tournaments/_tournament.html.slim
+++ b/app/views/tournaments/_tournament.html.slim
@@ -8,7 +8,7 @@
         => pluralize(tournament.players.active.count, 'player')
         ' -
         => tournament.user.try(:nrdb_username)
-        - if tournament.stream_url
+        - if tournament.stream_url.present?
           ' -
           => fa_icon 'video-camera'
       - if policy(tournament).destroy?


### PR DESCRIPTION
The same bug as the other issue, but missed. This change makes sure
the stream icon will not display on the tournament list for a
tournament with an empty string for its `stream_url`