### PR TITLE
Allow tournaments to run with a manual seed option

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,6 +20,7 @@
 @import 'global';
 @import 'font';
 @import 'pairings';
+@import 'players';
 @import 'standings';
 @import 'tournaments';
 @import 'help';

--- a/app/assets/stylesheets/players.sass
+++ b/app/assets/stylesheets/players.sass
@@ -1,0 +1,3 @@
+.players
+  .manual_seed
+    width: 80px

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -62,7 +62,7 @@ class PlayersController < ApplicationController
 
   def player_params
     params.require(:player)
-      .permit(:name, :corp_identity, :runner_identity, :first_round_bye)
+      .permit(:name, :corp_identity, :runner_identity, :first_round_bye, :manual_seed)
   end
 
   def set_player

--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -148,7 +148,7 @@ class TournamentsController < ApplicationController
   end
 
   def tournament_params
-    params.require(:tournament).permit(:name, :date, :private, :stream_url)
+    params.require(:tournament).permit(:name, :date, :private, :stream_url, :manual_seed)
   end
 
   def tome_import_params

--- a/app/models/standing_row.rb
+++ b/app/models/standing_row.rb
@@ -2,7 +2,7 @@ class StandingRow < ApplicationRecord
   belongs_to :stage
   belongs_to :player
 
-  delegate :name, :corp_identity, :runner_identity, to: :player
+  delegate :name, :corp_identity, :runner_identity, :manual_seed, to: :player
 
   def corp_identity
     identity(player.corp_identity)

--- a/app/services/standing.rb
+++ b/app/services/standing.rb
@@ -2,7 +2,7 @@ class Standing
   attr_reader :player, :points, :sos, :extended_sos, :corp_points, :runner_points
 
   delegate :name, :corp_identity, :runner_identity, to: :player
-  delegate :seed_in_stage, to: :player
+  delegate :tournament, :seed_in_stage, to: :player
 
   def initialize(player, values = {})
     @player = player
@@ -18,7 +18,7 @@ class Standing
   end
 
   def tiebreakers
-    [points, sos, extended_sos]
+    [points, -manual_seed, sos, extended_sos]
   end
 
   def corp_identity
@@ -27,5 +27,11 @@ class Standing
 
   def runner_identity
     player.runner_identity_object
+  end
+
+  def manual_seed
+    return 0 unless tournament.manual_seed?
+
+    player.manual_seed || Float::INFINITY
   end
 end

--- a/app/views/players/index.html.slim
+++ b/app/views/players/index.html.slim
@@ -1,4 +1,4 @@
-.col-12
+.col-12.players
   p
     = link_to meeting_tournament_players_path(@tournament), class: 'btn btn-primary' do
       => fa_icon 'list'
@@ -11,6 +11,8 @@
     => f.text_field :runner_identity, placeholder: 'Runner', class: 'runner_identities form-control mr-2'
     .form-check.mr-2
       => f.input_field :first_round_bye, as: :boolean, inline_label: 'First round bye?', class: 'form-check-input'
+    - if @tournament.manual_seed
+      => f.text_field :manual_seed, placeholder: 'Seed', class: 'manual_seed form-control mr-2'
     = button_tag type: :submit, class: 'btn btn-success' do
       => fa_icon 'plus'
       | Create
@@ -23,6 +25,8 @@
       => f.text_field :runner_identity, placeholder: 'Runner', class: 'runner_identities form-control mr-2'
       .form-check.mr-2
         => f.input_field :first_round_bye, as: :boolean, inline_label: 'First round bye?', class: 'form-check-input'
+      - if @tournament.manual_seed
+        => f.text_field :manual_seed, placeholder: 'Seed', class: 'manual_seed form-control mr-2'
       = button_tag type: :submit, class: 'btn btn-primary mr-2' do
         => fa_icon 'floppy-o'
         | Save

--- a/app/views/players/standings/_swiss.html.slim
+++ b/app/views/players/standings/_swiss.html.slim
@@ -6,6 +6,8 @@ table.table.table-striped.standings
       th Name
       th IDs
       th Points
+      - if @tournament.manual_seed?
+        th Seed
       th SOS
       th Extended SOS
   tbody
@@ -18,14 +20,18 @@ table.table.table-striped.standings
             = render row.corp_identity, points: row.corp_points, side: 'Corp'
             = render row.runner_identity, points: row.runner_points, side: 'Runner'
           td= row.points
+          - if @tournament.manual_seed?
+            td= row.manual_seed || '-'
           td= number_with_precision row.sos, precision: 4
           td= number_with_precision row.extended_sos, precision: 4
     - else
-      - stage.players.map(&:name).sort.each_with_index do |name, i|
+      - stage.players.sort.each_with_index do |player, i|
         tr
           td= i+1
-          td= name
+          td= player.name
           td.ids -
           td= 0
+          - if @tournament.manual_seed?
+            td= player.manual_seed || '-'
           td= number_with_precision 0, precision: 4
           td= number_with_precision 0, precision: 4

--- a/app/views/tournaments/_form.html.slim
+++ b/app/views/tournaments/_form.html.slim
@@ -6,3 +6,5 @@
   = f.input :stream_url, input_html: { class: 'form-control' }, label: 'Stream URL'
 .form-group
   = f.input :private, as: :boolean, inline_label: 'Private: Only I will be able to view this tournament'
+.form-group
+  = f.input :manual_seed, as: :boolean, inline_label: 'Use manual seeding for tiebreakers: Players can be assigned a "seed" value that will be used before all other tiebreakers (in ascending order; i.e. Seed 1 wins all ties)'

--- a/db/migrate/20200624134510_add_manual_seed_to_players.rb
+++ b/db/migrate/20200624134510_add_manual_seed_to_players.rb
@@ -1,0 +1,5 @@
+class AddManualSeedToPlayers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :players, :manual_seed, :integer
+  end
+end

--- a/db/migrate/20200624135125_add_manual_seed_to_tournaments.rb
+++ b/db/migrate/20200624135125_add_manual_seed_to_tournaments.rb
@@ -1,0 +1,5 @@
+class AddManualSeedToTournaments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tournaments, :manual_seed, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_18_191437) do
+ActiveRecord::Schema.define(version: 2020_06_24_135125) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,6 +59,8 @@ ActiveRecord::Schema.define(version: 2020_06_18_191437) do
     t.integer "seed"
     t.boolean "first_round_bye", default: false
     t.integer "previous_id"
+    t.boolean "deck_checked"
+    t.integer "manual_seed"
     t.index ["tournament_id"], name: "index_players_on_tournament_id"
   end
 
@@ -111,6 +113,7 @@ ActiveRecord::Schema.define(version: 2020_06_18_191437) do
     t.date "date"
     t.boolean "private", default: false
     t.string "stream_url"
+    t.boolean "manual_seed"
     t.index ["user_id"], name: "index_tournaments_on_user_id"
   end
 

--- a/spec/feature/players/create_player_spec.rb
+++ b/spec/feature/players/create_player_spec.rb
@@ -11,6 +11,22 @@ RSpec.describe 'creating a player' do
       check :player_first_round_bye
     end
 
+    context 'with manual_seed tournament' do
+      let(:tournament) { create(:tournament, manual_seed: true) }
+
+      before do
+        fill_in :player_manual_seed, with: 1
+      end
+
+      it 'provides seed field' do
+        click_button 'Create'
+
+        subject = Player.last
+
+        expect(subject.manual_seed).to eq(1)
+      end
+    end
+
     it 'creates player' do
       expect do
         click_button 'Create'

--- a/spec/feature/players/update_players_spec.rb
+++ b/spec/feature/players/update_players_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'updating players' do
-  let(:tournament) { create(:tournament) }
+  let(:tournament) { create(:tournament, manual_seed: true) }
 
   before do
     tournament.players << create(:player, name: 'Jack Player')
@@ -11,6 +11,7 @@ RSpec.describe 'updating players' do
       fill_in :player_corp_identity, with: 'Jinteki: Personal Evolution'
       fill_in :player_runner_identity, with: 'Gabriel Santiago'
       check :player_first_round_bye
+      fill_in :player_manual_seed, with: 3
       click_button 'Save'
     end
   end
@@ -29,6 +30,10 @@ RSpec.describe 'updating players' do
 
   it 'can update first round bye' do
     expect(tournament.players.first.first_round_bye).to eq(true)
+  end
+
+  it 'can update manual seed' do
+    expect(tournament.players.first.manual_seed).to eq(3)
   end
 
   it 'redirects to tournament player page' do

--- a/spec/feature/tournaments/create_tournament_spec.rb
+++ b/spec/feature/tournaments/create_tournament_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe 'creating a tournament' do
 
   it 'populates the tournament correctly' do
     fill_in :tournament_stream_url, with: 'https://twitch.tv'
+    check :tournament_manual_seed
 
     click_button 'Create'
 
@@ -23,6 +24,7 @@ RSpec.describe 'creating a tournament' do
       expect(subject.name).to eq('Test Tournament')
       expect(subject.stream_url).to eq('https://twitch.tv')
       expect(subject.created_at).not_to eq(nil)
+      expect(subject.manual_seed?).to eq(true)
     end
   end
 

--- a/spec/feature/tournaments/update_tournament_spec.rb
+++ b/spec/feature/tournaments/update_tournament_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'updating tournament' do
     fill_in :tournament_date, with: '2017/01/01'
     fill_in :tournament_stream_url, with: 'https://twitch.tv'
     check :tournament_private
+    check :tournament_manual_seed
   end
 
   it 'updates tournament' do
@@ -23,6 +24,7 @@ RSpec.describe 'updating tournament' do
       expect(tournament.date.to_s).to eq('2017-01-01')
       expect(tournament.stream_url).to eq('https://twitch.tv')
       expect(tournament.private?).to eq(true)
+      expect(tournament.manual_seed?).to eq(true)
     end
   end
 end

--- a/spec/services/standing_spec.rb
+++ b/spec/services/standing_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe Standing do
   end
 
   describe 'sorting' do
-    let(:other) { create(:player) }
+    # manual seeding should be ignored on unflagged tournaments
+    let(:other) { create(:player, manual_seed: 1) }
 
     it 'sorts by points' do
       expect(
@@ -101,6 +102,165 @@ RSpec.describe Standing do
           extended_sos: 1.3
         )
       ).to eq(1)
+    end
+
+    context 'with manual seed tournament' do
+      let(:tournament) { create(:tournament, manual_seed: true) }
+      let(:other) { create(:player, tournament: tournament, manual_seed: 2) }
+
+      context 'when player is seeded' do
+        let(:player) { create(:player, tournament: tournament, manual_seed: 1) }
+
+        it 'sorts by points' do
+          expect(
+            Standing.new(player, points: 3) <=> Standing.new(other, points: 0)
+          ).to eq(-1)
+          expect(
+            Standing.new(player, points: 1) <=> Standing.new(other, points: 5)
+          ).to eq(1)
+        end
+
+        it 'sorts by seed before sos' do
+          expect(
+            Standing.new(player,
+              points: 3,
+              sos: 2.0
+            ) <=> Standing.new(other,
+              points: 3,
+              sos: 1.8
+            )
+          ).to eq(-1)
+          expect(
+            Standing.new(player,
+              points: 3,
+              sos: 2.0
+            ) <=> Standing.new(other,
+              points: 3,
+              sos: 2.0
+            )
+          ).to eq(-1)
+          expect(
+            Standing.new(player,
+              points: 3,
+              sos: 1.4
+            ) <=> Standing.new(other,
+              points: 3,
+              sos: 1.8
+            )
+          ).to eq(-1)
+        end
+
+        context 'when seed is equal' do
+          let(:other) { create(:player, tournament: tournament, manual_seed: 1) }
+
+          it 'sorts by sos' do
+            expect(
+              Standing.new(player,
+                points: 3,
+                sos: 2.0
+              ) <=> Standing.new(other,
+                points: 3,
+                sos: 1.8
+              )
+            ).to eq(-1)
+            expect(
+              Standing.new(player,
+                points: 3,
+                sos: 2.0
+              ) <=> Standing.new(other,
+                points: 3,
+                sos: 2.0
+              )
+            ).to eq(0)
+            expect(
+              Standing.new(player,
+                points: 3,
+                sos: 1.4
+              ) <=> Standing.new(other,
+                points: 3,
+                sos: 1.8
+              )
+            ).to eq(1)
+          end
+        end
+      end
+
+      context 'when player is unseeded' do
+        let(:player) { create(:player, tournament: tournament, manual_seed: nil) }
+
+        it 'sorts by points' do
+          expect(
+            Standing.new(player, points: 3) <=> Standing.new(other, points: 0)
+          ).to eq(-1)
+          expect(
+            Standing.new(player, points: 1) <=> Standing.new(other, points: 5)
+          ).to eq(1)
+        end
+
+        it 'sorts by seed before sos' do
+          expect(
+            Standing.new(player,
+              points: 3,
+              sos: 2.0
+            ) <=> Standing.new(other,
+              points: 3,
+              sos: 1.8
+            )
+          ).to eq(1)
+          expect(
+            Standing.new(player,
+              points: 3,
+              sos: 2.0
+            ) <=> Standing.new(other,
+              points: 3,
+              sos: 2.0
+            )
+          ).to eq(1)
+          expect(
+            Standing.new(player,
+              points: 3,
+              sos: 1.4
+            ) <=> Standing.new(other,
+              points: 3,
+              sos: 1.8
+            )
+          ).to eq(1)
+        end
+
+        context 'when seed is equal' do
+          let(:other) { create(:player, tournament: tournament, manual_seed: nil) }
+
+          it 'sorts by sos' do
+            expect(
+              Standing.new(player,
+                points: 3,
+                sos: 2.0
+              ) <=> Standing.new(other,
+                points: 3,
+                sos: 1.8
+              )
+            ).to eq(-1)
+            expect(
+              Standing.new(player,
+                points: 3,
+                sos: 2.0
+              ) <=> Standing.new(other,
+                points: 3,
+                sos: 2.0
+              )
+            ).to eq(0)
+            expect(
+              Standing.new(player,
+                points: 3,
+                sos: 1.4
+              ) <=> Standing.new(other,
+                points: 3,
+                sos: 1.8
+              )
+            ).to eq(1)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
When this option is set, players can be assigned a seed value
which will break ties after points but before all other tiebreakers.
These values don't need to be sequential or unique.

Players are sorted in ascending value (i.e. seed 1 will win ties
with seed 2) and players with an unset value are considered to
have a seeding of infinity (i.e. will lose all ties to seeded
players). Players with matching seeds will have subsequent
tiebreakers applied as normal, i.e. SOS and then ESOS.