### PR TITLE
CSV Importer for easier player input of large tournaments

### DIFF
--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -2,7 +2,8 @@ class TournamentsController < ApplicationController
   before_action :set_tournament, only: [
       :show, :edit, :update, :destroy,
       :upload_to_abr, :save_json, :cut, :qr,
-      :import_from_tome, :apply_import_from_tome
+      :import_from_tome, :apply_import_from_tome,
+      :import_from_csv, :apply_import_from_csv
     ]
 
   def index
@@ -141,6 +142,18 @@ class TournamentsController < ApplicationController
     redirect_to tournament_players_path(@tournament)
   end
 
+  def import_from_csv
+    authorize @tournament, :edit?
+  end
+
+  def apply_import_from_csv
+    authorize @tournament, :edit?
+
+    Import::CSV_Import.new(csv_import_params[:csv_import]).apply(@tournament)
+
+    redirect_to tournament_players_path(@tournament)
+  end
+
   private
 
   def set_tournament
@@ -153,5 +166,9 @@ class TournamentsController < ApplicationController
 
   def tome_import_params
     params.require(:tome_import).permit(:tome_import)
+  end
+
+  def csv_import_params
+    params.require(:csv_import).permit(:csv_import)
   end
 end

--- a/app/services/import/csv_import.rb
+++ b/app/services/import/csv_import.rb
@@ -1,0 +1,30 @@
+require 'csv'
+
+module Import
+  class CSV_Import
+    attr_reader :csv_content
+
+    def initialize(csv_file)
+      @csv_content = CSV.parse(csv_file.read)
+    end
+
+    def apply(tournament)
+      Tournament.transaction do
+        tournament.stages.destroy_all
+        tournament.players.destroy_all
+
+        csv_content.each do |player_name, corp_id, runner_id|
+          player = tournament.players.create!(
+            name: player_name,
+            corp_identity: Identity.guess(corp_id)&.name,
+            runner_identity: Identity.guess(runner_id)&.name,
+            seed: nil,
+            first_round_bye: false,
+            active: true
+          )
+        end
+      end
+    end
+
+  end
+end

--- a/app/views/tournaments/edit.html.slim
+++ b/app/views/tournaments/edit.html.slim
@@ -28,3 +28,6 @@
     p= link_to import_from_tome_tournament_path(@tournament), class: 'btn btn-warning' do |f|
       => fa_icon 'book'
       | Import from TOME
+    p= link_to import_from_csv_tournament_path(@tournament), class: 'btn btn-warning' do
+      => fa_icon 'book'
+      | Import from CSV

--- a/app/views/tournaments/import_from_csv.html.slim
+++ b/app/views/tournaments/import_from_csv.html.slim
@@ -1,0 +1,14 @@
+.col-md-12
+  p This function takes a csv file with three columns: Player name, Corp ID, Runner ID
+
+  .alert.alert-danger
+    => fa_icon 'flask'
+    | This feature is very experimental. All existing tournament data will be DELETED as part of this import process.
+
+  = simple_form_for :csv_import, url: apply_import_from_csv_tournament_path(@tournament) do |f|
+    .form-group
+      = f.input :csv_import, label: 'CSV file', as: :file
+    .form-group
+      = button_tag type: :submit, class: 'btn btn-primary', data: { confirm: 'This action will DESTROY all existing data and CANNOT be reversed! Are you sure?' } do |f|
+        => fa_icon 'download'
+        | Import

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,8 @@ Rails.application.routes.draw do
     get :qr, on: :member
     get :import_from_tome, on: :member
     post :apply_import_from_tome, on: :member
+    get :import_from_csv, on: :member
+    post :apply_import_from_csv, on: :member
     get :shortlink, on: :collection
     get :not_found, on: :collection
     get :my, on: :collection


### PR DESCRIPTION
Added a button in the settings of a tournament that allows for importing a csv list of players and their IDs from e.g. a google docs registration form. This should come in handy for large tournaments (esp. Worlds).

Also, I have to warn you, that I have almost zero knowledge of neither Ruby nor Rails, but have only copy and pasted code from the TOME importer and rewritten it to do what I wanted. I have no idea, whether this is actually good code :sweat_smile: 